### PR TITLE
[BE] Discussion 단일 조회 기능 추가 및 테스트

### DIFF
--- a/backend/src/main/java/com/woowacourse/moragora/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/ControllerAdvice.java
@@ -1,8 +1,10 @@
 package com.woowacourse.moragora.controller;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import com.woowacourse.moragora.dto.ErrorResponse;
+import com.woowacourse.moragora.exception.DiscussionNotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
@@ -25,5 +27,11 @@ public class ControllerAdvice {
                 .collect(Collectors.joining(" "));
 
         return new ErrorResponse(errorMessage);
+    }
+
+    @ExceptionHandler(DiscussionNotFoundException.class)
+    @ResponseStatus(NOT_FOUND)
+    public ErrorResponse handleDiscussionNotFoundException(final Exception exception) {
+        return new ErrorResponse(exception.getMessage());
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/controller/DiscussionController.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/DiscussionController.java
@@ -1,12 +1,14 @@
 package com.woowacourse.moragora.controller;
 
 import com.woowacourse.moragora.dto.DiscussionRequest;
+import com.woowacourse.moragora.dto.DiscussionResponse;
 import com.woowacourse.moragora.dto.DiscussionsResponse;
 import com.woowacourse.moragora.service.DiscussionService;
 import java.net.URI;
 import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,5 +34,11 @@ public class DiscussionController {
     public ResponseEntity<DiscussionsResponse> findAll() {
         final DiscussionsResponse discussionsResponse = discussionService.findAll();
         return ResponseEntity.ok(discussionsResponse);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<DiscussionResponse> show(@PathVariable final Long id) {
+        final DiscussionResponse discussionResponse = discussionService.findById(id);
+        return ResponseEntity.ok(discussionResponse);
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/DiscussionResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/DiscussionResponse.java
@@ -3,9 +3,11 @@ package com.woowacourse.moragora.dto;
 import com.woowacourse.moragora.entity.Discussion;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class DiscussionResponse {
 
     private final long id;

--- a/backend/src/main/java/com/woowacourse/moragora/entity/Discussion.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/Discussion.java
@@ -42,4 +42,8 @@ public class Discussion extends BaseTimeEntity {
     public Discussion(final String title, final String content) {
         this(null, title, content);
     }
+
+    public void increaseViews() {
+        views++;
+    }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/exception/DiscussionNotFoundException.java
+++ b/backend/src/main/java/com/woowacourse/moragora/exception/DiscussionNotFoundException.java
@@ -1,0 +1,10 @@
+package com.woowacourse.moragora.exception;
+
+public class DiscussionNotFoundException extends RuntimeException {
+
+    private static final String MESSAGE = "토론 게시글이 존재하지 않습니다.";
+
+    public DiscussionNotFoundException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/moragora/repository/DiscussionRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/repository/DiscussionRepository.java
@@ -2,6 +2,7 @@ package com.woowacourse.moragora.repository;
 
 import com.woowacourse.moragora.entity.Discussion;
 import java.util.List;
+import java.util.Optional;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import org.springframework.stereotype.Repository;
@@ -27,5 +28,10 @@ public class DiscussionRepository {
 
     public List<Discussion> findAll() {
         return entityManager.createQuery("select d from Discussion d", Discussion.class).getResultList();
+    }
+
+    public Optional<Discussion> findById(final Long id) {
+        final Discussion discussion = entityManager.find(Discussion.class, id);
+        return Optional.ofNullable(discussion);
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/service/DiscussionService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/DiscussionService.java
@@ -36,4 +36,12 @@ public class DiscussionService {
 
         return new DiscussionsResponse(discussionResponses);
     }
+
+    @Transactional
+    public DiscussionResponse findById(final Long id) {
+        final Discussion discussion = discussionRepository.findById(id).get();
+        discussion.increaseViews();
+
+        return DiscussionResponse.from(discussion);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/service/DiscussionService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/DiscussionService.java
@@ -4,6 +4,7 @@ import com.woowacourse.moragora.dto.DiscussionRequest;
 import com.woowacourse.moragora.dto.DiscussionResponse;
 import com.woowacourse.moragora.dto.DiscussionsResponse;
 import com.woowacourse.moragora.entity.Discussion;
+import com.woowacourse.moragora.exception.DiscussionNotFoundException;
 import com.woowacourse.moragora.repository.DiscussionRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,7 +40,9 @@ public class DiscussionService {
 
     @Transactional
     public DiscussionResponse findById(final Long id) {
-        final Discussion discussion = discussionRepository.findById(id).get();
+        final Discussion discussion = discussionRepository.findById(id)
+                .orElseThrow(DiscussionNotFoundException::new);
+
         discussion.increaseViews();
 
         return DiscussionResponse.from(discussion);

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/AcceptanceTest.java
@@ -19,12 +19,19 @@ public class AcceptanceTest {
         RestAssured.port = port;
     }
 
-    protected ValidatableResponse post(final Object requestBody, final String uri) {
+    protected ValidatableResponse post(final String uri, final Object requestBody) {
         return RestAssured.given().log().all()
                 .body(requestBody)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when().post(uri)
+                .then().log().all();
+    }
+
+    protected ValidatableResponse get(final String uri) {
+        return RestAssured.given().log().all()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get(uri)
                 .then().log().all();
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/DiscussionAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/DiscussionAcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.moragora.acceptance;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 
 import com.woowacourse.moragora.dto.DiscussionRequest;
 import io.restassured.RestAssured;
@@ -21,7 +22,7 @@ public class DiscussionAcceptanceTest extends AcceptanceTest {
         final DiscussionRequest discussionRequest = new DiscussionRequest("제목", "내용");
 
         // when
-        ValidatableResponse response = post(discussionRequest, "/discussions");
+        ValidatableResponse response = post("/discussions", discussionRequest);
 
         // then
         response.statusCode(HttpStatus.CREATED.value())
@@ -35,9 +36,9 @@ public class DiscussionAcceptanceTest extends AcceptanceTest {
         final DiscussionRequest discussionRequest1 = new DiscussionRequest("제목1", "내용1");
         final DiscussionRequest discussionRequest2 = new DiscussionRequest("제목2", "내용2");
         final DiscussionRequest discussionRequest3 = new DiscussionRequest("제목3", "내용3");
-        post(discussionRequest1, "/discussions");
-        post(discussionRequest2, "/discussions");
-        post(discussionRequest3, "/discussions");
+        post("/discussions", discussionRequest1);
+        post("/discussions", discussionRequest2);
+        post("/discussions", discussionRequest3);
 
         // when
         final ValidatableResponse response = RestAssured.given().log().all()
@@ -50,5 +51,25 @@ public class DiscussionAcceptanceTest extends AcceptanceTest {
                 .body("discussions.id", contains(1, 2, 3))
                 .body("discussions.title", contains("제목1", "제목2", "제목3"))
                 .body("discussions.content", contains("내용1", "내용2", "내용3"));
+    }
+
+    @DisplayName("사용자가 특정 토론을 조회하면 해당 토론 게시글과 상태코드 200을 반환한다.")
+    @Test
+    void show() {
+        // given
+        final DiscussionRequest discussionRequest = new DiscussionRequest("제목", "내용");
+        final ValidatableResponse createResponse = post("/discussions", discussionRequest);
+        final String uri = createResponse.extract()
+                .header("Location");
+        final int id = Integer.parseInt(uri.split("/discussions/")[1]);
+
+        // when
+        final ValidatableResponse response = get(uri);
+
+        // then
+        response.statusCode(HttpStatus.OK.value())
+                .body("id", equalTo(id))
+                .body("title", equalTo("제목"))
+                .body("content", equalTo("내용"));
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/controller/DiscussionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/DiscussionControllerTest.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.moragora.dto.DiscussionRequest;
 import com.woowacourse.moragora.dto.DiscussionResponse;
 import com.woowacourse.moragora.dto.DiscussionsResponse;
+import com.woowacourse.moragora.exception.DiscussionNotFoundException;
 import com.woowacourse.moragora.service.DiscussionService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -162,5 +163,20 @@ public class DiscussionControllerTest {
                 .andExpect(jsonPath("$.views", equalTo(1)))
                 .andExpect(jsonPath("$.createdAt", notNullValue()))
                 .andExpect(jsonPath("$.updatedAt", notNullValue()));
+    }
+
+    @DisplayName("존재하지 않는 토론 게시글을 조회하면 예외가 발생한다.")
+    @Test
+    void show_throwsException_ifDiscussionNotFound() throws Exception {
+        // given
+        given(discussionService.findById(1L))
+                .willThrow(new DiscussionNotFoundException());
+
+        // when, then
+        mockMvc.perform(get("/discussions/1")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message", equalTo("토론 게시글이 존재하지 않습니다.")));
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/controller/DiscussionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/DiscussionControllerTest.java
@@ -139,4 +139,28 @@ public class DiscussionControllerTest {
                 .andExpect(jsonPath("$.discussions[*].createdAt", notNullValue()))
                 .andExpect(jsonPath("$.discussions[*].updatedAt", notNullValue()));
     }
+
+    @DisplayName("단일 게시글을 조회한다.")
+    @Test
+    void show() throws Exception {
+        // given
+        final DiscussionResponse discussionResponse =
+                new DiscussionResponse(1L, "제목", "내용", 1, 0, 0);
+
+        // when
+        given(discussionService.findById(1L))
+                .willReturn(discussionResponse);
+
+        // then
+        mockMvc.perform(get("/discussions/1")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", equalTo(1)))
+                .andExpect(jsonPath("$.title", equalTo("제목")))
+                .andExpect(jsonPath("$.content", equalTo("내용")))
+                .andExpect(jsonPath("$.views", equalTo(1)))
+                .andExpect(jsonPath("$.createdAt", notNullValue()))
+                .andExpect(jsonPath("$.updatedAt", notNullValue()));
+    }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/repository/DiscussionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/repository/DiscussionRepositoryTest.java
@@ -12,8 +12,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.jdbc.Sql;
 
 @SpringBootTest
+@Sql("/truncate.sql")
 class DiscussionRepositoryTest {
 
     @Autowired
@@ -69,5 +71,21 @@ class DiscussionRepositoryTest {
         assertThat(discussions).usingRecursiveComparison()
                 .comparingOnlyFields("title", "content")
                 .isEqualTo(List.of(discussion1, discussion2, discussion3));
+    }
+
+    @DisplayName("단일 게시글을 조회한다.")
+    @Test
+    void findById() {
+        // given
+        final Discussion discussion = new Discussion("제목", "내용");
+        final Long id = discussionRepository.save(discussion).getId();
+
+        // when
+        final Discussion foundDiscussion = discussionRepository.findById(id).get();
+
+        // then
+        assertThat(foundDiscussion).usingRecursiveComparison()
+                .ignoringFields("createdAt", "updatedAt")
+                .isEqualTo(new Discussion(id, "제목", "내용"));
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/service/DiscussionServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/DiscussionServiceTest.java
@@ -1,10 +1,12 @@
 package com.woowacourse.moragora.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.moragora.dto.DiscussionRequest;
 import com.woowacourse.moragora.dto.DiscussionResponse;
 import com.woowacourse.moragora.dto.DiscussionsResponse;
+import com.woowacourse.moragora.exception.DiscussionNotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
@@ -76,5 +78,13 @@ class DiscussionServiceTest {
         assertThat(response).usingRecursiveComparison()
                 .ignoringFields("id", "createdAt", "updatedAt")
                 .isEqualTo(expected);
+    }
+
+    @DisplayName("존재하지 않는 게시글 id를 조회할 경우 예외가 발생한다.")
+    @Test
+    void findById_throwsException_ifDiscussionNotFound() {
+        // given, when, then
+        assertThatThrownBy(() -> discussionService.findById(1L))
+                .isInstanceOf(DiscussionNotFoundException.class);
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/service/DiscussionServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/DiscussionServiceTest.java
@@ -12,9 +12,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.jdbc.Sql;
 
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@Sql("/truncate.sql")
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 class DiscussionServiceTest {
 
     @Autowired
@@ -52,5 +55,26 @@ class DiscussionServiceTest {
 
         // then
         assertThat(foundIds).containsExactly(expected1, expected2);
+    }
+
+    @DisplayName("id로 게시글을 조회한다.")
+    @Test
+    void findById() {
+        // given
+        final DiscussionRequest discussionRequest = new DiscussionRequest("제목", "내용");
+        final long savedId = discussionService.save(discussionRequest);
+        final DiscussionResponse expected = DiscussionResponse.builder()
+                .title("제목")
+                .content("내용")
+                .views(1)
+                .build();
+
+        // when
+        final DiscussionResponse response = discussionService.findById(savedId);
+
+        // then
+        assertThat(response).usingRecursiveComparison()
+                .ignoringFields("id", "createdAt", "updatedAt")
+                .isEqualTo(expected);
     }
 }

--- a/backend/src/test/resources/truncate.sql
+++ b/backend/src/test/resources/truncate.sql
@@ -1,0 +1,2 @@
+TRUNCATE TABLE discussion;
+ALTER TABLE discussion ALTER COLUMN id RESTART WITH 1;


### PR DESCRIPTION
Close #27 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/be/discussion-find-one -> develop

## 요구사항
- 토론 게시글 단일 조회 시 상세 정보를 반환한다.
- 존재하지 않는 토론 게시글 조회 시 Not Found를 반환한다.

## 논의하고 싶은 내용
CustomException 계층에 대해 고민해보아요.

