### PR TITLE
[BE] Meeting 단일 조회 기능 추가 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/moragora/ApplicationStartupRunner.java
+++ b/backend/src/main/java/com/woowacourse/moragora/ApplicationStartupRunner.java
@@ -30,13 +30,13 @@ public class ApplicationStartupRunner implements ApplicationListener<ContextRefr
     @Override
     public void onApplicationEvent(final ContextRefreshedEvent event) {
 
-        final User user1 = new User("아스피");
-        final User user2 = new User("필즈");
-        final User user3 = new User("포키");
-        final User user4 = new User("썬");
-        final User user5 = new User("우디");
-        final User user6 = new User("쿤");
-        final User user7 = new User("반듯");
+        final User user1 = new User("아스피", "aaa111@foo.com");
+        final User user2 = new User("필즈", "bbb222@foo.com");
+        final User user3 = new User("포키", "ccc333@foo.com");
+        final User user4 = new User("썬", "ddd444@foo.com");
+        final User user5 = new User("우디", "eee555@foo.com");
+        final User user6 = new User("쿤", "fff666@foo.com");
+        final User user7 = new User("반듯", "ggg777@foo.com");
 
         userRepository.save(user1);
         userRepository.save(user2);

--- a/backend/src/main/java/com/woowacourse/moragora/dto/MeetingResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/MeetingResponse.java
@@ -3,6 +3,7 @@ package com.woowacourse.moragora.dto;
 import com.woowacourse.moragora.entity.Meeting;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.Getter;
 
 @Getter
@@ -15,6 +16,7 @@ public class MeetingResponse {
     private final LocalDate endDate;
     private final LocalTime entranceTime;
     private final LocalTime leaveTime;
+    private final List<UserResponse> users;
 
     public MeetingResponse(final Long id,
                            final String name,
@@ -22,7 +24,8 @@ public class MeetingResponse {
                            final LocalDate startDate,
                            final LocalDate endDate,
                            final LocalTime entranceTime,
-                           final LocalTime leaveTime) {
+                           final LocalTime leaveTime,
+                           final List<UserResponse> usersResponse) {
         this.id = id;
         this.name = name;
         this.attendanceCount = attendanceCount;
@@ -30,9 +33,10 @@ public class MeetingResponse {
         this.endDate = endDate;
         this.entranceTime = entranceTime;
         this.leaveTime = leaveTime;
+        this.users = usersResponse;
     }
 
-    public static MeetingResponse from(final Meeting meeting) {
+    public static MeetingResponse from(final Meeting meeting, final List<UserResponse> usersResponse) {
         return new MeetingResponse(
                 meeting.getId(),
                 meeting.getName(),
@@ -40,6 +44,7 @@ public class MeetingResponse {
                 meeting.getStartDate(),
                 meeting.getEndDate(),
                 meeting.getEntranceTime(),
-                meeting.getLeaveTime());
+                meeting.getLeaveTime(),
+                usersResponse);
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/UserResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/UserResponse.java
@@ -14,7 +14,7 @@ public class UserResponse {
     private String nickName;
     private int tardyCount;
 
-    public UserResponse(Long id, String email, String nickName, int tardyCount) {
+    public UserResponse(final Long id, final String email, final String nickName, final int tardyCount) {
         this.id = id;
         this.email = email;
         this.nickName = nickName;

--- a/backend/src/main/java/com/woowacourse/moragora/dto/UserResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/UserResponse.java
@@ -1,17 +1,33 @@
 package com.woowacourse.moragora.dto;
 
+import com.woowacourse.moragora.entity.Attendance;
+import com.woowacourse.moragora.entity.User;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 public class UserResponse {
 
-    private final Long id;
-    private final String name;
-    private final int absentCount;
+    private Long id;
+    private String email;
+    private String nickName;
+    private int tardyCount;
 
-    public UserResponse(final Long id, final String name, final int absentCount) {
+    public UserResponse(Long id, String email, String nickName, int tardyCount) {
         this.id = id;
-        this.name = name;
-        this.absentCount = absentCount;
+        this.email = email;
+        this.nickName = nickName;
+        this.tardyCount = tardyCount;
+    }
+
+    public static UserResponse from(final Attendance attendance) {
+        User user = attendance.getUser();
+        return new UserResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                attendance.getTardyCount()
+        );
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/entity/User.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/User.java
@@ -24,7 +24,10 @@ public class User {
     @Column(nullable = false, length = MAX_NAME_LENGTH)
     private String name;
 
-    public User(final String name) {
+    private String email;
+
+    public User(final String name, final String email) {
         this.name = name;
+        this.email = email;
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
@@ -62,17 +62,17 @@ public class MeetingAcceptanceTest extends AcceptanceTest {
                 .body("entranceTime", equalTo("10:00:00"))
                 .body("leaveTime", equalTo("18:00:00"));
 
-        List<UserResponse> usersResponse = response.extract().jsonPath().getList("users", UserResponse.class);
+        final List<UserResponse> usersResponse = response.extract().jsonPath().getList("users", UserResponse.class);
 
-        List<Long> ids = usersResponse.stream()
+        final List<Long> ids = usersResponse.stream()
                 .map(UserResponse::getId)
                 .collect(Collectors.toUnmodifiableList());
 
-        List<String> names = usersResponse.stream()
+        final List<String> names = usersResponse.stream()
                 .map(UserResponse::getNickName)
                 .collect(Collectors.toUnmodifiableList());
 
-        List<String> emails = usersResponse.stream()
+        final List<String> emails = usersResponse.stream()
                 .map(UserResponse::getEmail)
                 .collect(Collectors.toUnmodifiableList());
 

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
@@ -1,16 +1,19 @@
 package com.woowacourse.moragora.acceptance;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
 import com.woowacourse.moragora.dto.MeetingRequest;
 import com.woowacourse.moragora.dto.UserAttendanceRequest;
 import com.woowacourse.moragora.dto.UserAttendancesRequest;
+import com.woowacourse.moragora.dto.UserResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -37,9 +40,9 @@ public class MeetingAcceptanceTest extends AcceptanceTest {
         // then
         response.statusCode(HttpStatus.CREATED.value())
                 .header("Location", notNullValue());
-
     }
 
+    // TODO assertThat 검증을 RestAssured 로 변경
     @DisplayName("사용자가 특정 모임을 조회하면 해당 모임 상세 정보와 상태코드 200을 반환한다.")
     @Test
     void findOne() {
@@ -58,6 +61,32 @@ public class MeetingAcceptanceTest extends AcceptanceTest {
                 .body("endDate", equalTo("2022-08-10"))
                 .body("entranceTime", equalTo("10:00:00"))
                 .body("leaveTime", equalTo("18:00:00"));
+
+        List<UserResponse> usersResponse = response.extract().jsonPath().getList("users", UserResponse.class);
+
+        List<Long> ids = usersResponse.stream()
+                .map(UserResponse::getId)
+                .collect(Collectors.toUnmodifiableList());
+
+        List<String> names = usersResponse.stream()
+                .map(UserResponse::getNickName)
+                .collect(Collectors.toUnmodifiableList());
+
+        List<String> emails = usersResponse.stream()
+                .map(UserResponse::getEmail)
+                .collect(Collectors.toUnmodifiableList());
+
+        assertThat(ids).containsExactlyInAnyOrder(1L, 2L, 3L, 4L, 5L, 6L, 7L);
+        assertThat(names).containsExactlyInAnyOrder("아스피", "필즈", "포키", "썬", "우디", "쿤", "반듯");
+        assertThat(emails).containsExactlyInAnyOrder(
+                "aaa111@foo.com",
+                "bbb222@foo.com",
+                "ccc333@foo.com",
+                "ddd444@foo.com",
+                "eee555@foo.com",
+                "fff666@foo.com",
+                "ggg777@foo.com"
+        );
     }
 
     @DisplayName("모임의 출석을 마감하면 총 모임 횟수와 결석한 참가자들의 결일을 증가시키고 상태코드 204을 반환한다.")

--- a/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
@@ -13,9 +13,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.moragora.dto.MeetingRequest;
 import com.woowacourse.moragora.dto.MeetingResponse;
+import com.woowacourse.moragora.dto.UserResponse;
 import com.woowacourse.moragora.service.MeetingService;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,10 +64,15 @@ class MeetingControllerTest {
                 .andExpect(header().string("Location", equalTo("/meetings/" + 1)));
     }
 
+    // TODO userResponse 테스트 작성
     @DisplayName("단일 미팅 방을 조회한다.")
     @Test
     void findOne() throws Exception {
         // given
+        final List<UserResponse> usersResponse = new ArrayList<>();
+        usersResponse.add(new UserResponse(1L, "abc@naver.com", "foo", 5));
+        usersResponse.add(new UserResponse(2L, "def@naver.com", "boo", 8));
+
         final MeetingResponse meetingResponse = new MeetingResponse(
                 1L,
                 "모임1",
@@ -72,7 +80,9 @@ class MeetingControllerTest {
                 LocalDate.of(2022, 7, 10),
                 LocalDate.of(2022, 8, 10),
                 LocalTime.of(10, 0),
-                LocalTime.of(18, 0));
+                LocalTime.of(18, 0),
+                usersResponse
+        );
 
         // when
         given(meetingService.findById(1L))
@@ -89,6 +99,7 @@ class MeetingControllerTest {
                 .andExpect(jsonPath("$.startDate", equalTo("2022-07-10")))
                 .andExpect(jsonPath("$.endDate", equalTo("2022-08-10")))
                 .andExpect(jsonPath("$.entranceTime", equalTo("10:00:00")))
+                .andExpect(jsonPath("$.leaveTime", equalTo("18:00:00")))
                 .andExpect(jsonPath("$.leaveTime", equalTo("18:00:00")));
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
@@ -38,6 +38,7 @@ class MeetingServiceTest {
         assertThat(expected).isNotNull();
     }
 
+    // TODO userResponse 테스트 작성
     @DisplayName("id로 모임 상세 정보를 조회한다.")
     @Test
     void findById() {
@@ -50,13 +51,16 @@ class MeetingServiceTest {
                 LocalDate.of(2022, 7, 10),
                 LocalDate.of(2022, 8, 10),
                 LocalTime.of(10, 0),
-                LocalTime.of(18, 0));
+                LocalTime.of(18, 0),
+                null
+        );
 
         // when
         final MeetingResponse response = meetingService.findById(id);
 
         // then
         assertThat(response).usingRecursiveComparison()
+                .ignoringFields("users")
                 .isEqualTo(expectedMeetingResponse);
     }
 }


### PR DESCRIPTION
close #70 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/meeting-attendances-find-one -> dev

## 요구사항
- Meeting 단일 조회시 해당 Meeting의 참석하는 User 들의 정보와 지각 횟수을 반환한다.

## 변경사항
- User Entity의 email 필드 추가.

## 참고사항
- git commit 내용이 아래와 같이 깨지는 현상이 있음
![image](https://user-images.githubusercontent.com/66164361/178152218-01d3d20f-dd7e-45a9-8f8c-e5f79356edec.png)
- 내용은 아래와 같음
     feat: Meeting 단일 조회 기능 추가 구현
