### PR TITLE
[BE] 로그인 기능 추가 및 테스트

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,11 @@ dependencies {
     // rest-assured
     testImplementation 'io.rest-assured:rest-assured:4.4.0'
     testImplementation 'io.rest-assured:spring-mock-mvc:4.4.0'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/woowacourse/ApplicationStartupRunner.java
+++ b/backend/src/main/java/com/woowacourse/ApplicationStartupRunner.java
@@ -1,4 +1,4 @@
-package com.woowacourse.moragora;
+package com.woowacourse;
 
 import com.woowacourse.moragora.entity.Attendance;
 import com.woowacourse.moragora.entity.Meeting;

--- a/backend/src/main/java/com/woowacourse/MoragoraApplication.java
+++ b/backend/src/main/java/com/woowacourse/MoragoraApplication.java
@@ -1,4 +1,4 @@
-package com.woowacourse.moragora;
+package com.woowacourse;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/backend/src/main/java/com/woowacourse/auth/config/LoginArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/auth/config/LoginArgumentResolver.java
@@ -1,0 +1,33 @@
+package com.woowacourse.auth.config;
+
+import com.woowacourse.auth.support.AuthenticationPrincipal;
+import com.woowacourse.auth.support.AuthorizationExtractor;
+import com.woowacourse.auth.support.JwtTokenProvider;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public LoginArgumentResolver(final JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
+    }
+
+    @Override
+    public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+                                  final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
+        final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        final String token = AuthorizationExtractor.extract(request);
+        return jwtTokenProvider.getPayload(token);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/auth/config/LoginArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/auth/config/LoginArgumentResolver.java
@@ -26,7 +26,7 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
                                   final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
-        final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        final HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
         final String token = AuthorizationExtractor.extract(request);
         return jwtTokenProvider.getPayload(token);
     }

--- a/backend/src/main/java/com/woowacourse/auth/config/LoginInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/auth/config/LoginInterceptor.java
@@ -1,8 +1,8 @@
 package com.woowacourse.auth.config;
 
+import com.woowacourse.auth.support.Authentication;
 import com.woowacourse.auth.support.AuthorizationExtractor;
 import com.woowacourse.auth.support.JwtTokenProvider;
-import com.woowacourse.auth.support.Authentication;
 import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -20,8 +20,8 @@ public class LoginInterceptor implements HandlerInterceptor {
     }
 
     @Override
-    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler)
-            throws Exception {
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response,
+                             final Object handler) {
         if (request.getMethod().equals((HttpMethod.OPTIONS.name()))) {
             return true;
         }
@@ -39,8 +39,9 @@ public class LoginInterceptor implements HandlerInterceptor {
 
     private boolean isNotAnnotated(final Object handler) {
         final HandlerMethod handlerMethod = (HandlerMethod) handler;
-        final Authentication login = handlerMethod.getMethodAnnotation(Authentication.class);
-        return Objects.isNull(login);
+        final Authentication classAnnotation = handlerMethod.getBean().getClass().getAnnotation(Authentication.class);
+        final Authentication methodAnnotation = handlerMethod.getMethodAnnotation(Authentication.class);
+        return Objects.isNull(classAnnotation) && Objects.isNull(methodAnnotation);
     }
 
     private boolean isValidateToken(final HttpServletRequest request) {

--- a/backend/src/main/java/com/woowacourse/auth/config/LoginInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/auth/config/LoginInterceptor.java
@@ -1,0 +1,49 @@
+package com.woowacourse.auth.config;
+
+import com.woowacourse.auth.exception.UnauthorizedTokenException;
+import com.woowacourse.auth.support.AuthorizationExtractor;
+import com.woowacourse.auth.support.JwtTokenProvider;
+import com.woowacourse.auth.support.Login;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class LoginInterceptor implements HandlerInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public LoginInterceptor(final JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler)
+            throws Exception {
+        if (request.getMethod().equals((HttpMethod.OPTIONS.name()))) {
+            return true;
+        }
+
+        if (!hasAnnotation(handler)) {
+            return true;
+        }
+
+        validateToken(request);
+        return true;
+    }
+
+    private boolean hasAnnotation(final Object handler) {
+        final HandlerMethod handlerMethod = (HandlerMethod) handler;
+
+        return null != handlerMethod.getMethodAnnotation(Login.class);
+    }
+
+    private void validateToken(final HttpServletRequest request) {
+        final String token = AuthorizationExtractor.extract(request);
+        final boolean isValidate = jwtTokenProvider.validateToken(token);
+        if (!isValidate) {
+            throw new UnauthorizedTokenException();
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/auth/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/auth/config/WebConfig.java
@@ -19,13 +19,19 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
-        registry.addInterceptor(new LoginInterceptor(jwtTokenProvider))
+        final LoginInterceptor interceptor = loginInterceptor();
+        registry.addInterceptor(interceptor)
                 .addPathPatterns("/**");
     }
 
     @Override
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginArgumentResolver());
+    }
+
+    @Bean
+    public LoginInterceptor loginInterceptor() {
+        return new LoginInterceptor(jwtTokenProvider);
     }
 
     @Bean

--- a/backend/src/main/java/com/woowacourse/auth/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/auth/config/WebConfig.java
@@ -1,7 +1,10 @@
 package com.woowacourse.auth.config;
 
 import com.woowacourse.auth.support.JwtTokenProvider;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -18,5 +21,15 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(new LoginInterceptor(jwtTokenProvider))
                 .addPathPatterns("/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginArgumentResolver());
+    }
+
+    @Bean
+    public LoginArgumentResolver loginArgumentResolver() {
+        return new LoginArgumentResolver(jwtTokenProvider);
     }
 }

--- a/backend/src/main/java/com/woowacourse/auth/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/auth/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.woowacourse.auth.config;
+
+import com.woowacourse.auth.support.JwtTokenProvider;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public WebConfig(final JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(new LoginInterceptor(jwtTokenProvider))
+                .addPathPatterns("/**");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/woowacourse/auth/controller/AuthController.java
@@ -1,0 +1,25 @@
+package com.woowacourse.auth.controller;
+
+import com.woowacourse.auth.dto.LoginRequest;
+import com.woowacourse.auth.dto.LoginResponse;
+import com.woowacourse.auth.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(final AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody final LoginRequest loginRequest) {
+        final LoginResponse loginResponse = authService.createToken(loginRequest);
+        return ResponseEntity.ok(loginResponse);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/auth/dto/LoginRequest.java
+++ b/backend/src/main/java/com/woowacourse/auth/dto/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.woowacourse.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class LoginRequest {
+    private String email;
+    private String password;
+
+    public LoginRequest(final String email, final String password) {
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/auth/dto/LoginRequest.java
+++ b/backend/src/main/java/com/woowacourse/auth/dto/LoginRequest.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 public class LoginRequest {
+
     private String email;
     private String password;
 

--- a/backend/src/main/java/com/woowacourse/auth/dto/LoginResponse.java
+++ b/backend/src/main/java/com/woowacourse/auth/dto/LoginResponse.java
@@ -1,0 +1,13 @@
+package com.woowacourse.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoginResponse {
+
+    private final String accessToken;
+
+    public LoginResponse(final String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/auth/exception/LoginFailException.java
+++ b/backend/src/main/java/com/woowacourse/auth/exception/LoginFailException.java
@@ -1,0 +1,10 @@
+package com.woowacourse.auth.exception;
+
+public class LoginFailException extends RuntimeException {
+
+    private static final String MESSAGE = "이메일이나 비밀번호가 틀렸습니다.";
+
+    public LoginFailException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/auth/exception/UnauthorizedTokenException.java
+++ b/backend/src/main/java/com/woowacourse/auth/exception/UnauthorizedTokenException.java
@@ -1,0 +1,4 @@
+package com.woowacourse.auth.exception;
+
+public class UnauthorizedTokenException extends RuntimeException {
+}

--- a/backend/src/main/java/com/woowacourse/auth/exception/UnauthorizedTokenException.java
+++ b/backend/src/main/java/com/woowacourse/auth/exception/UnauthorizedTokenException.java
@@ -1,4 +1,0 @@
-package com.woowacourse.auth.exception;
-
-public class UnauthorizedTokenException extends RuntimeException {
-}

--- a/backend/src/main/java/com/woowacourse/auth/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/auth/service/AuthService.java
@@ -1,0 +1,28 @@
+package com.woowacourse.auth.service;
+
+import com.woowacourse.auth.dto.LoginRequest;
+import com.woowacourse.auth.dto.LoginResponse;
+import com.woowacourse.auth.support.JwtTokenProvider;
+import com.woowacourse.moragora.entity.user.User;
+import com.woowacourse.moragora.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    public AuthService(final JwtTokenProvider jwtTokenProvider, final UserRepository userRepository) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userRepository = userRepository;
+    }
+
+    public LoginResponse createToken(final LoginRequest loginRequest) {
+        final User user = userRepository.findByEmail(loginRequest.getEmail()).get();
+        final String accessToken = jwtTokenProvider.createToken(String.valueOf(user.getId()));
+        return new LoginResponse(accessToken);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/auth/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package com.woowacourse.auth.service;
 
 import com.woowacourse.auth.dto.LoginRequest;
 import com.woowacourse.auth.dto.LoginResponse;
+import com.woowacourse.auth.exception.LoginFailException;
 import com.woowacourse.auth.support.JwtTokenProvider;
 import com.woowacourse.moragora.entity.user.User;
 import com.woowacourse.moragora.repository.UserRepository;
@@ -21,7 +22,10 @@ public class AuthService {
     }
 
     public LoginResponse createToken(final LoginRequest loginRequest) {
-        final User user = userRepository.findByEmail(loginRequest.getEmail()).get();
+        final User user = userRepository.findByEmail(loginRequest.getEmail())
+                .orElseThrow(() -> new LoginFailException());
+
+        user.checkPassword(loginRequest.getPassword());
         final String accessToken = jwtTokenProvider.createToken(String.valueOf(user.getId()));
         return new LoginResponse(accessToken);
     }

--- a/backend/src/main/java/com/woowacourse/auth/support/Authentication.java
+++ b/backend/src/main/java/com/woowacourse/auth/support/Authentication.java
@@ -6,6 +6,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * 이 어노테이션이 메서드, 클래스 레벨에 있을 경우 인가가 필요합니다.
+ */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})

--- a/backend/src/main/java/com/woowacourse/auth/support/Authentication.java
+++ b/backend/src/main/java/com/woowacourse/auth/support/Authentication.java
@@ -9,5 +9,5 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
-public @interface Login {
+public @interface Authentication {
 }

--- a/backend/src/main/java/com/woowacourse/auth/support/AuthenticationPrincipal.java
+++ b/backend/src/main/java/com/woowacourse/auth/support/AuthenticationPrincipal.java
@@ -1,0 +1,11 @@
+package com.woowacourse.auth.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticationPrincipal {
+}

--- a/backend/src/main/java/com/woowacourse/auth/support/AuthorizationExtractor.java
+++ b/backend/src/main/java/com/woowacourse/auth/support/AuthorizationExtractor.java
@@ -1,0 +1,40 @@
+package com.woowacourse.auth.support;
+
+import java.util.Enumeration;
+import javax.servlet.http.HttpServletRequest;
+
+public class AuthorizationExtractor {
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String ACCESS_TOKEN_TYPE = AuthorizationExtractor.class.getSimpleName() + ".ACCESS_TOKEN_TYPE";
+    public static final String BEARER_TYPE = "Bearer";
+
+    public static String extract(final HttpServletRequest request) {
+        final Enumeration<String> headers = extractHeaders(request);
+        while (headers.hasMoreElements()) {
+            final String value = headers.nextElement();
+            if (isBearerToken(value)) {
+                final String token = value.substring(BEARER_TYPE.length()).trim();
+                request.setAttribute(ACCESS_TOKEN_TYPE, value.substring(0, BEARER_TYPE.length()).trim());
+                return parseToken(token);
+            }
+        }
+        return null;
+    }
+
+    private static Enumeration<String> extractHeaders(final HttpServletRequest request) {
+        final Enumeration<String> headers = request.getHeaders(AUTHORIZATION);
+        return headers;
+    }
+
+    private static boolean isBearerToken(final String value) {
+        return value.toLowerCase().startsWith(BEARER_TYPE.toLowerCase());
+    }
+
+    private static String parseToken(final String token) {
+        final int commaIndex = token.indexOf(',');
+        if (commaIndex > 0) {
+            return token.substring(0, commaIndex);
+        }
+        return token;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/auth/support/AuthorizationExtractor.java
+++ b/backend/src/main/java/com/woowacourse/auth/support/AuthorizationExtractor.java
@@ -4,9 +4,10 @@ import java.util.Enumeration;
 import javax.servlet.http.HttpServletRequest;
 
 public class AuthorizationExtractor {
-    public static final String AUTHORIZATION = "Authorization";
-    public static final String ACCESS_TOKEN_TYPE = AuthorizationExtractor.class.getSimpleName() + ".ACCESS_TOKEN_TYPE";
-    public static final String BEARER_TYPE = "Bearer";
+
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String ACCESS_TOKEN_TYPE = AuthorizationExtractor.class.getSimpleName() + ".ACCESS_TOKEN_TYPE";
+    private static final String BEARER_TYPE = "Bearer";
 
     public static String extract(final HttpServletRequest request) {
         final Enumeration<String> headers = extractHeaders(request);

--- a/backend/src/main/java/com/woowacourse/auth/support/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/auth/support/JwtTokenProvider.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class JwtTokenProvider {
+
     private final SecretKey secretKey;
     private final long validityInMilliseconds;
 

--- a/backend/src/main/java/com/woowacourse/auth/support/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/auth/support/JwtTokenProvider.java
@@ -1,5 +1,8 @@
 package com.woowacourse.auth.support;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -30,5 +33,18 @@ public class JwtTokenProvider {
                 .setExpiration(validity)
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
+    }
+
+    public boolean validateToken(final String token) {
+        try {
+            final Jws<Claims> claims = parseClaimsJws(token);
+            return !claims.getBody().getExpiration().before(new Date());
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private Jws<Claims> parseClaimsJws(final String token) {
+        return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
     }
 }

--- a/backend/src/main/java/com/woowacourse/auth/support/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/auth/support/JwtTokenProvider.java
@@ -1,0 +1,34 @@
+package com.woowacourse.auth.support;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+    private final SecretKey secretKey;
+    private final long validityInMilliseconds;
+
+    public JwtTokenProvider(@Value("${security.jwt.token.secret-key}") final String secretKey,
+                            @Value("${security.jwt.token.expire-length}") final long validityInMilliseconds) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.validityInMilliseconds = validityInMilliseconds;
+    }
+
+    public String createToken(final String payload) {
+        final Date now = new Date();
+        final Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(payload)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/auth/support/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/auth/support/JwtTokenProvider.java
@@ -35,6 +35,12 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    public String getPayload(final String token) {
+        return parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
     public boolean validateToken(final String token) {
         try {
             final Jws<Claims> claims = parseClaimsJws(token);
@@ -45,6 +51,9 @@ public class JwtTokenProvider {
     }
 
     private Jws<Claims> parseClaimsJws(final String token) {
-        return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token);
     }
 }

--- a/backend/src/main/java/com/woowacourse/auth/support/Login.java
+++ b/backend/src/main/java/com/woowacourse/auth/support/Login.java
@@ -1,0 +1,13 @@
+package com.woowacourse.auth.support;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface Login {
+}

--- a/backend/src/main/java/com/woowacourse/moragora/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/ControllerAdvice.java
@@ -2,10 +2,8 @@ package com.woowacourse.moragora.controller;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import com.woowacourse.auth.exception.LoginFailException;
-import com.woowacourse.auth.exception.UnauthorizedTokenException;
 import com.woowacourse.moragora.dto.ErrorResponse;
 import com.woowacourse.moragora.exception.InvalidFormatException;
 import com.woowacourse.moragora.exception.MeetingNotFoundException;
@@ -59,10 +57,5 @@ public class ControllerAdvice {
     @ResponseStatus(BAD_REQUEST)
     public ErrorResponse handleLoginFailException(final Exception exception) {
         return new ErrorResponse(exception.getMessage());
-    }
-
-    @ExceptionHandler(UnauthorizedTokenException.class)
-    @ResponseStatus(UNAUTHORIZED)
-    public void handleUnauthorizedException() {
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/ControllerAdvice.java
@@ -3,6 +3,7 @@ package com.woowacourse.moragora.controller;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
+import com.woowacourse.auth.exception.LoginFailException;
 import com.woowacourse.moragora.dto.ErrorResponse;
 import com.woowacourse.moragora.exception.InvalidFormatException;
 import com.woowacourse.moragora.exception.MeetingNotFoundException;
@@ -49,6 +50,12 @@ public class ControllerAdvice {
     @ExceptionHandler(InvalidFormatException.class)
     @ResponseStatus(BAD_REQUEST)
     public ErrorResponse handleInvalidFormatException(final Exception exception) {
+        return new ErrorResponse(exception.getMessage());
+    }
+
+    @ExceptionHandler(LoginFailException.class)
+    @ResponseStatus(BAD_REQUEST)
+    public ErrorResponse handleLoginFailException(final Exception exception) {
         return new ErrorResponse(exception.getMessage());
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/ControllerAdvice.java
@@ -2,8 +2,10 @@ package com.woowacourse.moragora.controller;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import com.woowacourse.auth.exception.LoginFailException;
+import com.woowacourse.auth.exception.UnauthorizedTokenException;
 import com.woowacourse.moragora.dto.ErrorResponse;
 import com.woowacourse.moragora.exception.InvalidFormatException;
 import com.woowacourse.moragora.exception.MeetingNotFoundException;
@@ -57,5 +59,10 @@ public class ControllerAdvice {
     @ResponseStatus(BAD_REQUEST)
     public ErrorResponse handleLoginFailException(final Exception exception) {
         return new ErrorResponse(exception.getMessage());
+    }
+
+    @ExceptionHandler(UnauthorizedTokenException.class)
+    @ResponseStatus(UNAUTHORIZED)
+    public void handleUnauthorizedException() {
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/controller/MeetingController.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/MeetingController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/meetings")
+@Authentication
 public class MeetingController {
 
     private final MeetingService meetingService;
@@ -27,21 +28,18 @@ public class MeetingController {
     }
 
     @PostMapping
-    @Authentication
     public ResponseEntity<Void> add(@RequestBody @Valid final MeetingRequest request) {
         final Long id = meetingService.save(request);
         return ResponseEntity.created(URI.create("/meetings/" + id)).build();
     }
 
     @GetMapping("/{id}")
-    @Authentication
     public ResponseEntity<MeetingResponse> findOne(@PathVariable final Long id) {
         final MeetingResponse meetingResponse = meetingService.findById(id);
         return ResponseEntity.ok(meetingResponse);
     }
 
     @PatchMapping("/{id}")
-    @Authentication
     public ResponseEntity<Void> endAttendance(@PathVariable final Long id,
                                               @RequestBody final UserAttendancesRequest request) {
         meetingService.updateAttendance(id, request);

--- a/backend/src/main/java/com/woowacourse/moragora/controller/MeetingController.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/MeetingController.java
@@ -1,5 +1,6 @@
 package com.woowacourse.moragora.controller;
 
+import com.woowacourse.auth.support.Login;
 import com.woowacourse.moragora.dto.MeetingRequest;
 import com.woowacourse.moragora.dto.MeetingResponse;
 import com.woowacourse.moragora.dto.UserAttendancesRequest;
@@ -26,18 +27,21 @@ public class MeetingController {
     }
 
     @PostMapping
+    @Login
     public ResponseEntity<Void> add(@RequestBody @Valid final MeetingRequest request) {
         final Long id = meetingService.save(request);
         return ResponseEntity.created(URI.create("/meetings/" + id)).build();
     }
 
     @GetMapping("/{id}")
+    @Login
     public ResponseEntity<MeetingResponse> findOne(@PathVariable final Long id) {
         final MeetingResponse meetingResponse = meetingService.findById(id);
         return ResponseEntity.ok(meetingResponse);
     }
 
     @PatchMapping("/{id}")
+    @Login
     public ResponseEntity<Void> endAttendance(@PathVariable final Long id,
                                               @RequestBody final UserAttendancesRequest request) {
         meetingService.updateAttendance(id, request);

--- a/backend/src/main/java/com/woowacourse/moragora/controller/MeetingController.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/MeetingController.java
@@ -1,6 +1,6 @@
 package com.woowacourse.moragora.controller;
 
-import com.woowacourse.auth.support.Login;
+import com.woowacourse.auth.support.Authentication;
 import com.woowacourse.moragora.dto.MeetingRequest;
 import com.woowacourse.moragora.dto.MeetingResponse;
 import com.woowacourse.moragora.dto.UserAttendancesRequest;
@@ -27,21 +27,21 @@ public class MeetingController {
     }
 
     @PostMapping
-    @Login
+    @Authentication
     public ResponseEntity<Void> add(@RequestBody @Valid final MeetingRequest request) {
         final Long id = meetingService.save(request);
         return ResponseEntity.created(URI.create("/meetings/" + id)).build();
     }
 
     @GetMapping("/{id}")
-    @Login
+    @Authentication
     public ResponseEntity<MeetingResponse> findOne(@PathVariable final Long id) {
         final MeetingResponse meetingResponse = meetingService.findById(id);
         return ResponseEntity.ok(meetingResponse);
     }
 
     @PatchMapping("/{id}")
-    @Login
+    @Authentication
     public ResponseEntity<Void> endAttendance(@PathVariable final Long id,
                                               @RequestBody final UserAttendancesRequest request) {
         meetingService.updateAttendance(id, request);

--- a/backend/src/main/java/com/woowacourse/moragora/entity/user/EncodedPassword.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/user/EncodedPassword.java
@@ -1,5 +1,6 @@
 package com.woowacourse.moragora.entity.user;
 
+import com.woowacourse.moragora.util.CryptoEncoder;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import lombok.Getter;
@@ -20,5 +21,10 @@ public class EncodedPassword {
     public static EncodedPassword fromRawValue(final String plainValue) {
         final RawPassword rawPassword = new RawPassword(plainValue);
         return new EncodedPassword(rawPassword.encode());
+    }
+
+    public boolean isSamePassword(final String plainPassword) {
+        final String encryptedPassword = CryptoEncoder.encrypt(plainPassword);
+        return encryptedPassword.equals(value);
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/entity/user/User.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/user/User.java
@@ -1,5 +1,6 @@
 package com.woowacourse.moragora.entity.user;
 
+import com.woowacourse.auth.exception.LoginFailException;
 import com.woowacourse.moragora.exception.InvalidFormatException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -56,6 +57,12 @@ public class User {
         final Matcher matcher = PATTERN_NICKNAME.matcher(nickname);
         if (!matcher.matches()) {
             throw new InvalidFormatException();
+        }
+    }
+
+    public void checkPassword(final String plainPassword) {
+        if (!password.isSamePassword(plainPassword)) {
+            throw new LoginFailException();
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/repository/UserRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/repository/UserRepository.java
@@ -4,6 +4,7 @@ import com.woowacourse.moragora.entity.user.User;
 import java.util.List;
 import java.util.Optional;
 import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
 import javax.persistence.PersistenceContext;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,10 +33,13 @@ public class UserRepository {
     }
 
     public Optional<User> findByEmail(final String email) {
-        final User user = entityManager.createQuery("select u from User u where u.email = :email", User.class)
-                .setParameter("email", email)
-                .getSingleResult();
-
-        return Optional.ofNullable(user);
+        try {
+            User user = entityManager.createQuery("select u from User u where u.email = :email", User.class)
+                    .setParameter("email", email)
+                    .getSingleResult();
+            return Optional.of(user);
+        } catch (NoResultException exception) {
+            return Optional.empty();
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/repository/UserRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.woowacourse.moragora.repository;
 
 import com.woowacourse.moragora.entity.user.User;
 import java.util.List;
+import java.util.Optional;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import org.springframework.stereotype.Repository;
@@ -28,5 +29,13 @@ public class UserRepository {
         return entityManager.createQuery("select u from User u where u.id in :userIds", User.class)
                 .setParameter("userIds", userIds)
                 .getResultList();
+    }
+
+    public Optional<User> findByEmail(final String email) {
+        final User user = entityManager.createQuery("select u from User u where u.email = :email", User.class)
+                .setParameter("email", email)
+                .getSingleResult();
+
+        return Optional.ofNullable(user);
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -9,3 +9,8 @@ logging.level:
   org.hibernate:
     SQL: debug
     type: trace
+security:
+  jwt:
+    token:
+      secret-key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ih1aovtQShabQ7l0cINw4k1fagApg3qLWiB8Kt59Lno
+      expire-length: 3600000

--- a/backend/src/test/java/com/woowacourse/auth/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/auth/acceptance/AuthAcceptanceTest.java
@@ -1,0 +1,34 @@
+package com.woowacourse.auth.acceptance;
+
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.woowacourse.auth.dto.LoginRequest;
+import com.woowacourse.moragora.acceptance.AcceptanceTest;
+import com.woowacourse.moragora.dto.UserRequest;
+import io.restassured.response.ValidatableResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+@DisplayName("인증 관련 기능")
+public class AuthAcceptanceTest extends AcceptanceTest {
+
+    @DisplayName("로그인에 성공할 때 토큰을 발급한다.")
+    @Test
+    void login() {
+        // given
+        final String email = "kun@naver.com";
+        final String password = "1234smart!";
+        final UserRequest userRequest = new UserRequest(email, password, "kun");
+        post("/users", userRequest);
+
+        final LoginRequest loginRequest = new LoginRequest(email, password);
+
+        // when
+        final ValidatableResponse response = post("/login", loginRequest);
+
+        // then
+        response.statusCode(HttpStatus.OK.value())
+                .body("accessToken", notNullValue());
+    }
+}

--- a/backend/src/test/java/com/woowacourse/auth/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/auth/acceptance/AuthAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.auth.acceptance;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
 import com.woowacourse.auth.dto.LoginRequest;
@@ -13,7 +14,7 @@ import org.springframework.http.HttpStatus;
 @DisplayName("인증 관련 기능")
 public class AuthAcceptanceTest extends AcceptanceTest {
 
-    @DisplayName("로그인에 성공할 때 토큰을 발급한다.")
+    @DisplayName("로그인에 성공할 때 토큰과 상태코드 200을 반환한다.")
     @Test
     void login() {
         // given
@@ -30,5 +31,24 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         // then
         response.statusCode(HttpStatus.OK.value())
                 .body("accessToken", notNullValue());
+    }
+
+    @DisplayName("이메일 또는 비밀번호가 잘못되었을 때 로그인에 실패하고 상태코드 400을 반환한다.")
+    @Test
+    void login_fail() {
+        // given
+        final String email = "kun@naver.com";
+        final String password = "1234smart!";
+        final UserRequest userRequest = new UserRequest(email, password, "kun");
+        post("/users", userRequest);
+
+        final LoginRequest loginRequest = new LoginRequest(email, "password123!");
+
+        // when
+        final ValidatableResponse response = post("/login", loginRequest);
+
+        // then
+        response.statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", equalTo("이메일이나 비밀번호가 틀렸습니다."));
     }
 }

--- a/backend/src/test/java/com/woowacourse/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/auth/controller/AuthControllerTest.java
@@ -1,0 +1,52 @@
+package com.woowacourse.auth.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.auth.dto.LoginRequest;
+import com.woowacourse.auth.dto.LoginResponse;
+import com.woowacourse.auth.service.AuthService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = {AuthController.class})
+public class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthService authService;
+
+    @DisplayName("로그인에 성공한다.")
+    @Test
+    void login() throws Exception {
+        // given
+        final LoginRequest loginRequest = new LoginRequest("kun@naver.com", "1234smart!");
+        final String accessToken = "fake_token";
+
+        given(authService.createToken(any(LoginRequest.class)))
+                .willReturn(new LoginResponse(accessToken));
+
+        // when, then
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("accessToken").value(accessToken));
+    }
+}

--- a/backend/src/test/java/com/woowacourse/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/auth/controller/AuthControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.auth.dto.LoginRequest;
 import com.woowacourse.auth.dto.LoginResponse;
+import com.woowacourse.auth.exception.LoginFailException;
 import com.woowacourse.auth.service.AuthService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,5 +49,23 @@ public class AuthControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("accessToken").value(accessToken));
+    }
+
+    @DisplayName("로그인에 실패한다.")
+    @Test
+    void login_fail() throws Exception {
+        // given
+        final LoginRequest loginRequest = new LoginRequest("kun@naver.com", "1234smart!");
+
+        given(authService.createToken(any(LoginRequest.class)))
+                .willThrow(new LoginFailException());
+
+        // when, then
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("message").value("이메일이나 비밀번호가 틀렸습니다."));
     }
 }

--- a/backend/src/test/java/com/woowacourse/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/auth/controller/AuthControllerTest.java
@@ -12,6 +12,7 @@ import com.woowacourse.auth.dto.LoginRequest;
 import com.woowacourse.auth.dto.LoginResponse;
 import com.woowacourse.auth.exception.LoginFailException;
 import com.woowacourse.auth.service.AuthService;
+import com.woowacourse.auth.support.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +22,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = {AuthController.class})
+@MockBean(value = {JwtTokenProvider.class})
 public class AuthControllerTest {
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/auth/service/AuthServiceTest.java
@@ -1,0 +1,42 @@
+package com.woowacourse.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.auth.dto.LoginRequest;
+import com.woowacourse.auth.dto.LoginResponse;
+import com.woowacourse.moragora.dto.UserRequest;
+import com.woowacourse.moragora.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private UserService userService;
+
+    @DisplayName("로그인 정보를 받아 토큰을 생성한다.")
+    @Test
+    void createToken() {
+        // given
+        final String email = "kun@email.com";
+        final String password = "qwerasdf123!";
+        final UserRequest userRequest = new UserRequest(email, password, "kun");
+        userService.create(userRequest);
+
+        final LoginRequest loginRequest = new LoginRequest(email, password);
+
+        // when
+        final LoginResponse response = authService.createToken(loginRequest);
+
+        // then
+        assertThat(response.getAccessToken()).isNotNull();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/auth/service/AuthServiceTest.java
@@ -1,9 +1,11 @@
 package com.woowacourse.auth.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.auth.dto.LoginRequest;
 import com.woowacourse.auth.dto.LoginResponse;
+import com.woowacourse.auth.exception.LoginFailException;
 import com.woowacourse.moragora.dto.UserRequest;
 import com.woowacourse.moragora.service.UserService;
 import org.junit.jupiter.api.DisplayName;
@@ -38,5 +40,35 @@ public class AuthServiceTest {
 
         // then
         assertThat(response.getAccessToken()).isNotNull();
+    }
+
+    @DisplayName("존재하지 않는 이메일로 로그인 시도시 예외가 발생한다.")
+    @Test
+    void createToken_throwsException_ifEmailIsNotExist() {
+        // given
+        final String email = "kun@email.com";
+        final String password = "qwerasdf123!";
+
+        final LoginRequest loginRequest = new LoginRequest(email, password);
+
+        // when, then
+        assertThatThrownBy(() -> authService.createToken(loginRequest))
+                .isInstanceOf(LoginFailException.class);
+    }
+
+    @DisplayName("잘못된 비밀번호로 로그인 시도시 예외가 발생한다.")
+    @Test
+    void createToken_throwsException_ifPasswordIsWrong() {
+        // given
+        final String email = "kun@email.com";
+        final String password = "qwerasdf123!";
+        final UserRequest userRequest = new UserRequest(email, password, "kun");
+        userService.create(userRequest);
+
+        final LoginRequest loginRequest = new LoginRequest(email, "smart1234!");
+
+        // when, then
+        assertThatThrownBy(() -> authService.createToken(loginRequest))
+                .isInstanceOf(LoginFailException.class);
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/AcceptanceTest.java
@@ -1,6 +1,10 @@
 package com.woowacourse.moragora.acceptance;
 
+import com.woowacourse.auth.dto.LoginRequest;
+import com.woowacourse.moragora.dto.UserRequest;
 import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,10 +33,41 @@ public class AcceptanceTest {
                 .then().log().all();
     }
 
+    protected ValidatableResponse post(final String uri, final Object requestBody, final String token) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(token)
+                .body(requestBody)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().post(uri)
+                .then().log().all();
+    }
+
     protected ValidatableResponse get(final String uri) {
         return RestAssured.given().log().all()
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when().get(uri)
                 .then().log().all();
+    }
+
+    protected ValidatableResponse get(final String uri, final String token) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(token)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get(uri)
+                .then().log().all();
+    }
+
+    protected String signUpAndGetToken() {
+        final String email = "test@naver.com";
+        final String password = "1234asdfg!";
+
+        final UserRequest userRequest = new UserRequest(email, password, "kun");
+        post("/users", userRequest);
+
+        final LoginRequest loginRequest = new LoginRequest(email, password);
+        final ExtractableResponse<Response> response = post("/login", loginRequest).extract();
+
+        return response.jsonPath().get("accessToken");
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
@@ -34,7 +34,7 @@ public class MeetingAcceptanceTest extends AcceptanceTest {
         );
 
         // when
-        final ValidatableResponse response = post("/meetings", meetingRequest);
+        final ValidatableResponse response = post("/meetings", meetingRequest, signUpAndGetToken());
 
         // then
         response.statusCode(HttpStatus.CREATED.value())
@@ -48,7 +48,7 @@ public class MeetingAcceptanceTest extends AcceptanceTest {
         final int id = 1;
 
         // when
-        final ValidatableResponse response = get("/meetings/" + id);
+        final ValidatableResponse response = get("/meetings/" + id, signUpAndGetToken());
 
         // then
         response.statusCode(HttpStatus.OK.value())
@@ -88,6 +88,7 @@ public class MeetingAcceptanceTest extends AcceptanceTest {
 
         // when
         final ValidatableResponse response = RestAssured.given().log().all()
+                .auth().oauth2(signUpAndGetToken())
                 .body(userAttendancesRequest)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)

--- a/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.auth.config.WebConfig;
 import com.woowacourse.moragora.dto.MeetingRequest;
 import com.woowacourse.moragora.dto.MeetingResponse;
 import com.woowacourse.moragora.dto.UserResponse;
@@ -34,6 +35,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = {MeetingController.class})
+@MockBean(value = {WebConfig.class})
 class MeetingControllerTest {
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/moragora/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/UserControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.auth.config.WebConfig;
 import com.woowacourse.moragora.dto.UserRequest;
 import com.woowacourse.moragora.service.UserService;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +24,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = {UserController.class})
+@MockBean(value = {WebConfig.class})
 public class UserControllerTest {
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/moragora/entity/user/UserTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/entity/user/UserTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.moragora.entity.user;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.auth.exception.LoginFailException;
 import com.woowacourse.moragora.exception.InvalidFormatException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,5 +45,30 @@ class UserTest {
         // when, then
         assertThatThrownBy(() -> new User("kun@email.com", encodedPassword, nickname))
                 .isInstanceOf(InvalidFormatException.class);
+    }
+
+    @DisplayName("입력한 비밀번호와 자신의 비밀번호를 비교한다.")
+    @Test
+    void checkPassword() {
+        // given
+        final String plainPassword = "rightPassword123!";
+        final User user = new User("asdf@naver.com", EncodedPassword.fromRawValue(plainPassword), "kun");
+
+        // when, then
+        assertThatCode(() -> user.checkPassword(plainPassword))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("입력한 비밀번호와 자신의 비밀번호와 다를시 예외가 발생한다..")
+    @Test
+    void checkPassword_throwsException_ifPasswordIsDifferent() {
+        // given
+        final String plainPassword = "rightPassword123!";
+        final User user = new User("asdf@naver.com", EncodedPassword.fromRawValue(plainPassword), "kun");
+        final String wrongPassword = "wrongPassword123!";
+
+        // when, then
+        assertThatThrownBy(() -> user.checkPassword(wrongPassword))
+                .isInstanceOf(LoginFailException.class);
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/repository/UserRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/repository/UserRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.woowacourse.moragora.entity.user.EncodedPassword;
 import com.woowacourse.moragora.entity.user.User;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,5 +39,19 @@ class UserRepositoryTest {
         final List<User> users = userRepository.findByIds(List.of(1L, 2L, 3L));
 
         assertThat(users).hasSize(3);
+    }
+
+    @DisplayName("이메일로 유저를 검색한다.")
+    @Test
+    void findByEmail() {
+        // given
+        final String email = "kun@email.com";
+        userRepository.save(new User(email, EncodedPassword.fromRawValue("qweradsf123!"), "kun"));
+
+        // when
+        final Optional<User> user = userRepository.findByEmail(email);
+
+        // then
+        assertThat(user.isPresent()).isTrue();
     }
 }


### PR DESCRIPTION
Close #96 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/user-login -> dev

## 요구사항
- 로그인 기능 구현 및 토큰을 발급한다.
- 토큰 유효성 검증 후, 인터셉터로 컨트롤러 호출을 차단한다.
- 토큰에서 유저 정보 가져오는 ArgumentResolver 구현 후, 아직 적용은 안 시킴

## 변경사항
- 인수 테스트 중 로그인이 필요한 기능에는 토큰 헤더 추가

## 논의하고 싶은 내용
### Controller 계층 테스트의 범위
- Controller 테스트에서는 인터셉터의 동작을 확인할 필요가 없다고 생각을 했습니다. 따라서 Webconfig를 mock 객체로 변경했습니다.

### 인터셉터가 필요한 경로 등록법
`@Login`이라는 커스텀 어노테이션을 만들어주었습니다.
토큰 검증이 필요한 경로를 추가할 시에 webconfig에서 따로 등록해줄 필요 없이, 핸들러 메서드에 `@Login`을 달아주시면 등록됩니다.

```java
    @PostMapping
    @Login
    public ResponseEntity<Void> add(@RequestBody @Valid final MeetingRequest request) {
        final Long id = meetingService.save(request);
        return ResponseEntity.created(URI.create("/meetings/" + id)).build();
    }
```

### 커스텀 Argument Resolver
토큰에서 페이로드를 추출을 도와주는 어노테이션으로 `@AuthenticationPrincipal` 을 추가했습니다.
변경점이 많아서 아직 적용은 안 시켰고, 각자 기능 개발할 때 이 어노테이션을 사용해주면 될 것 같습니다.