### PR TITLE
[BE] Meeting Controller에 Argument Resolver 적용

### DIFF
--- a/backend/src/main/java/com/woowacourse/auth/config/LoginArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/auth/config/LoginArgumentResolver.java
@@ -28,6 +28,6 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
                                   final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
         final HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
         final String token = AuthorizationExtractor.extract(request);
-        return jwtTokenProvider.getPayload(token);
+        return Long.valueOf(jwtTokenProvider.getPayload(token));
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/controller/MeetingController.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/MeetingController.java
@@ -1,6 +1,7 @@
 package com.woowacourse.moragora.controller;
 
 import com.woowacourse.auth.support.Authentication;
+import com.woowacourse.auth.support.AuthenticationPrincipal;
 import com.woowacourse.moragora.dto.MeetingRequest;
 import com.woowacourse.moragora.dto.MeetingResponse;
 import com.woowacourse.moragora.dto.UserAttendancesRequest;
@@ -28,14 +29,16 @@ public class MeetingController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> add(@RequestBody @Valid final MeetingRequest request) {
-        final Long id = meetingService.save(request, 1L);
+    public ResponseEntity<Void> add(@RequestBody @Valid final MeetingRequest request,
+                                    @AuthenticationPrincipal final Long loginId) {
+        final Long id = meetingService.save(request, loginId);
         return ResponseEntity.created(URI.create("/meetings/" + id)).build();
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<MeetingResponse> findOne(@PathVariable final Long id) {
-        final MeetingResponse meetingResponse = meetingService.findById(id, 1L);
+    public ResponseEntity<MeetingResponse> findOne(@PathVariable final Long id,
+                                                   @AuthenticationPrincipal final Long loginId) {
+        final MeetingResponse meetingResponse = meetingService.findById(id, loginId);
         return ResponseEntity.ok(meetingResponse);
     }
 

--- a/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
@@ -36,6 +36,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+// TODO: LoginArgumentResolver return mocking 시도
 @WebMvcTest(controllers = {MeetingController.class})
 @MockBean(value = {WebConfig.class})
 class MeetingControllerTest {

--- a/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
@@ -2,7 +2,8 @@ package com.woowacourse.moragora.controller;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -62,7 +63,7 @@ class MeetingControllerTest {
         );
 
         // when
-        given(meetingService.save(any(MeetingRequest.class), anyLong()))
+        given(meetingService.save(any(MeetingRequest.class), nullable(Long.class)))
                 .willReturn(1L);
 
         // then
@@ -88,7 +89,7 @@ class MeetingControllerTest {
         );
 
         // when
-        given(meetingService.save(any(MeetingRequest.class), anyLong()))
+        given(meetingService.save(any(MeetingRequest.class), nullable(Long.class)))
                 .willThrow(new IllegalStartEndDateException());
 
         // then
@@ -178,7 +179,7 @@ class MeetingControllerTest {
         );
 
         // when
-        given(meetingService.findById(1L, 1L))
+        given(meetingService.findById(eq(1L), nullable(Long.class)))
                 .willReturn(meetingResponse);
 
         // then
@@ -192,7 +193,6 @@ class MeetingControllerTest {
                 .andExpect(jsonPath("$.startDate", equalTo("2022-07-10")))
                 .andExpect(jsonPath("$.endDate", equalTo("2022-08-10")))
                 .andExpect(jsonPath("$.entranceTime", equalTo("10:00:00")))
-                .andExpect(jsonPath("$.leaveTime", equalTo("18:00:00")))
                 .andExpect(jsonPath("$.leaveTime", equalTo("18:00:00")));
     }
 }


### PR DESCRIPTION
Close #126 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/apply-argument-resolver -> dev

## 요구사항
- controller parameter에 Argument Resolver를 적용한 후 Controller Test를 통과시킨다

## 변경사항
- service mocking 시 argument로 null을 허용하여 test 깨지는 문제 해결

## 논의하고 싶은 내용
- argument mocking시, `any()` method에는 `@NotNull`이 적용되어 있어 null이 들어올 경우 mocking하지 않습니다. 따라서 null이 들어올 경우에도 mocking되길 원한다면 `nullable()` method를 사용해야 합니다.

<!--Close #issue_number를 작성한다.-->