### PR TITLE
[FE] user attendance 체크 기능 추가

### DIFF
--- a/frontend/src/components/UserItem/index.tsx
+++ b/frontend/src/components/UserItem/index.tsx
@@ -54,7 +54,6 @@ const UserItem: React.FC<UserItemProps> = ({ user, meetingId }) => {
 
       if (!response.ok) {
         setChecked(!checked);
-        alert('출석체크에 실패했습니다.');
       }
     } catch (error) {
       alert('출석체크중 오류가 발생했습니다.');

--- a/frontend/src/components/UserItem/index.tsx
+++ b/frontend/src/components/UserItem/index.tsx
@@ -16,12 +16,15 @@ type User = {
 
 type UserItemProps = {
   user: Omit<User, 'accessToken'>;
-  handleChecked: (user: Omit<User, 'accessToken'>, checked: boolean) => void;
+  onAttendanceCheck: (
+    user: Omit<User, 'accessToken'>,
+    checked: boolean
+  ) => void;
 };
 
-const UserItem: React.FC<UserItemProps> = ({ user, handleChecked }) => {
+const UserItem: React.FC<UserItemProps> = ({ user, onAttendanceCheck }) => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    handleChecked(user, e.target.checked);
+    onAttendanceCheck(user, e.target.checked);
   };
 
   return (

--- a/frontend/src/components/UserItem/index.tsx
+++ b/frontend/src/components/UserItem/index.tsx
@@ -11,13 +11,19 @@ type User = {
   nickname: string;
   accessToken: null | string;
   tardyCount: number;
+  attendanceStatus: string;
 };
 
 type UserItemProps = {
   user: Omit<User, 'accessToken'>;
+  handleChecked: (user: Omit<User, 'accessToken'>, checked: boolean) => void;
 };
 
-const UserItem: React.FC<UserItemProps> = ({ user }) => {
+const UserItem: React.FC<UserItemProps> = ({ user, handleChecked }) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleChecked(user, e.target.checked);
+  };
+
   return (
     <S.Layout>
       <S.Box>
@@ -28,7 +34,10 @@ const UserItem: React.FC<UserItemProps> = ({ user }) => {
           ))}
         </S.CoffeeIconImageBox>
       </S.Box>
-      <Checkbox />
+      <Checkbox
+        onChange={handleChange}
+        checked={user.attendanceStatus === 'tardy' ? false : true}
+      />
     </S.Layout>
   );
 };

--- a/frontend/src/mocks/fixtures/users.ts
+++ b/frontend/src/mocks/fixtures/users.ts
@@ -4,6 +4,7 @@ export type User = {
   password: string;
   nickname: string;
   accessToken: string | null;
+  attendanceStatus: string;
 };
 
 const generateIndexes = (length: number) => Array.from({ length });
@@ -14,6 +15,7 @@ const users = generateIndexes(100).map<User>((_, id) => ({
   password: `user${id}pw!`,
   nickname: `user${id}`,
   accessToken: null,
+  attendanceStatus: 'tardy',
 }));
 
 export default users;

--- a/frontend/src/mocks/fixtures/users.ts
+++ b/frontend/src/mocks/fixtures/users.ts
@@ -4,7 +4,7 @@ export type User = {
   password: string;
   nickname: string;
   accessToken: string | null;
-  attendanceStatus: string;
+  attendanceStatus: 'present' | 'tardy';
 };
 
 const generateIndexes = (length: number) => Array.from({ length });

--- a/frontend/src/mocks/handlers/meetingHandler.ts
+++ b/frontend/src/mocks/handlers/meetingHandler.ts
@@ -8,7 +8,7 @@ type MeetingAttendanceRequestBody = {
 }[];
 
 type UserAttendanceCheckRequestBody = {
-  attendanceStatus: string;
+  attendanceStatus: 'present' | 'tardy';
 };
 
 const DELAY = 700;

--- a/frontend/src/mocks/handlers/meetingHandler.ts
+++ b/frontend/src/mocks/handlers/meetingHandler.ts
@@ -7,6 +7,10 @@ type MeetingAttendanceRequestBody = {
   isAbsent: boolean;
 }[];
 
+type UserAttendanceCheckRequestBody = {
+  attendanceStatus: string;
+};
+
 const DELAY = 700;
 
 export default [
@@ -47,26 +51,26 @@ export default [
     return res(ctx.status(204), ctx.delay(DELAY));
   }),
 
-  rest.put<{ attendanceStatus: string }, { meetingId: string; userId: string }>(
-    `/meetings/:meetingId/users/:userId`,
-    (req, res, ctx) => {
-      const { meetingId, userId } = req.params;
+  rest.put<
+    UserAttendanceCheckRequestBody,
+    { meetingId: string; userId: string }
+  >(`/meetings/:meetingId/users/:userId`, (req, res, ctx) => {
+    const { meetingId, userId } = req.params;
 
-      const targetMeeting = meetings.find(
-        (meeting) => meeting.id === Number(meetingId)
-      );
-      if (!targetMeeting) {
-        return res(ctx.status(404), ctx.delay(DELAY));
-      }
-
-      const targetUser = users.find((user) => user.id === Number(userId));
-      if (!targetUser) {
-        return res(ctx.status(404), ctx.delay(DELAY));
-      }
-
-      targetUser.attendanceStatus = req.body.attendanceStatus;
-
-      return res(ctx.status(204), ctx.delay(DELAY));
+    const targetMeeting = meetings.find(
+      (meeting) => meeting.id === Number(meetingId)
+    );
+    if (!targetMeeting) {
+      return res(ctx.status(404), ctx.delay(DELAY));
     }
-  ),
+
+    const targetUser = users.find((user) => user.id === Number(userId));
+    if (!targetUser) {
+      return res(ctx.status(404), ctx.delay(DELAY));
+    }
+
+    targetUser.attendanceStatus = req.body.attendanceStatus;
+
+    return res(ctx.status(204), ctx.delay(DELAY));
+  }),
 ];

--- a/frontend/src/mocks/handlers/meetingHandler.ts
+++ b/frontend/src/mocks/handlers/meetingHandler.ts
@@ -46,4 +46,27 @@ export default [
 
     return res(ctx.status(204), ctx.delay(DELAY));
   }),
+
+  rest.put<{ attendanceStatus: string }, { meetingId: string; userId: string }>(
+    `/meetings/:meetingId/users/:userId`,
+    (req, res, ctx) => {
+      const { meetingId, userId } = req.params;
+
+      const targetMeeting = meetings.find(
+        (meeting) => meeting.id === Number(meetingId)
+      );
+      if (!targetMeeting) {
+        return res(ctx.status(404), ctx.delay(DELAY));
+      }
+
+      const targetUser = users.find((user) => user.id === Number(userId));
+      if (!targetUser) {
+        return res(ctx.status(404), ctx.delay(DELAY));
+      }
+
+      targetUser.attendanceStatus = req.body.attendanceStatus;
+
+      return res(ctx.status(204), ctx.delay(DELAY));
+    }
+  ),
 ];

--- a/frontend/src/mocks/handlers/userHandler.ts
+++ b/frontend/src/mocks/handlers/userHandler.ts
@@ -61,6 +61,7 @@ export default [
       password,
       nickname,
       accessToken: null,
+      attendanceStatus: 'tardy',
     };
 
     users.push(newUser);

--- a/frontend/src/pages/MeetingPage/MeetingPage.styled.ts
+++ b/frontend/src/pages/MeetingPage/MeetingPage.styled.ts
@@ -59,7 +59,7 @@ export const UserDataBox = styled.div`
   justify-content: center;
 `;
 
-export const Form = styled.form`
+export const UserListBox = styled.div`
   display: flex;
   overflow: hidden;
 `;

--- a/frontend/src/pages/MeetingPage/index.tsx
+++ b/frontend/src/pages/MeetingPage/index.tsx
@@ -49,7 +49,7 @@ const MeetingPage = () => {
     refetch,
   } = useFetch<MeetingResponseBody>(`/meetings/${id}`);
 
-  const handleChecked = async (
+  const handleAttendanceCheck = async (
     user: Omit<User, 'accessToken'>,
     checked: boolean
   ) => {
@@ -115,7 +115,7 @@ const MeetingPage = () => {
                 <UserItem
                   key={user.id}
                   user={user}
-                  handleChecked={handleChecked}
+                  onAttendanceCheck={handleAttendanceCheck}
                 />
               ))}
             </S.UserList>

--- a/frontend/src/pages/MeetingPage/index.tsx
+++ b/frontend/src/pages/MeetingPage/index.tsx
@@ -16,7 +16,7 @@ type User = {
   nickname: string;
   accessToken: null | string;
   tardyCount: number;
-  attendanceStatus: string;
+  attendanceStatus: 'present' | 'tardy';
 };
 
 type MeetingResponseBody = {

--- a/frontend/src/pages/MeetingPage/index.tsx
+++ b/frontend/src/pages/MeetingPage/index.tsx
@@ -30,16 +30,6 @@ type MeetingResponseBody = {
   attendanceCount: number;
 };
 
-const userAttendanceFetch = async (url: string, payload: any) => {
-  return fetch(url, {
-    method: 'PUT',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(payload),
-  });
-};
-
 const MeetingPage = () => {
   const { id } = useParams();
   const {
@@ -48,24 +38,6 @@ const MeetingPage = () => {
     error: isError,
     refetch,
   } = useFetch<MeetingResponseBody>(`/meetings/${id}`);
-
-  const handleAttendanceCheck = async (
-    user: Omit<User, 'accessToken'>,
-    checked: boolean
-  ) => {
-    const response = await userAttendanceFetch(
-      `/meetings/${id}/users/${user.id}`,
-      {
-        attendanceStatus: checked ? 'present' : 'tardy',
-      }
-    );
-
-    if (!response.ok) {
-      alert('출석체크에 실패했습니다.');
-    }
-
-    refetch();
-  };
 
   if (isLoading) {
     return (
@@ -111,13 +83,10 @@ const MeetingPage = () => {
         <S.UserListSection>
           <S.UserListBox>
             <S.UserList>
-              {meetingState.users.map((user) => (
-                <UserItem
-                  key={user.id}
-                  user={user}
-                  onAttendanceCheck={handleAttendanceCheck}
-                />
-              ))}
+              {meetingState &&
+                meetingState.users.map((user) => (
+                  <UserItem key={user.id} meetingId={id} user={user} />
+                ))}
             </S.UserList>
           </S.UserListBox>
         </S.UserListSection>

--- a/frontend/src/pages/MeetingPage/index.tsx
+++ b/frontend/src/pages/MeetingPage/index.tsx
@@ -53,9 +53,16 @@ const MeetingPage = () => {
     user: Omit<User, 'accessToken'>,
     checked: boolean
   ) => {
-    await userAttendanceFetch(`/meetings/${id}/users/${user.id}`, {
-      attendanceStatus: checked ? 'present' : 'tardy',
-    });
+    const response = await userAttendanceFetch(
+      `/meetings/${id}/users/${user.id}`,
+      {
+        attendanceStatus: checked ? 'present' : 'tardy',
+      }
+    );
+
+    if (!response.ok) {
+      alert('출석체크에 실패했습니다.');
+    }
 
     refetch();
   };

--- a/frontend/src/pages/MeetingPage/index.tsx
+++ b/frontend/src/pages/MeetingPage/index.tsx
@@ -1,15 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import * as S from './MeetingPage.styled';
 import Footer from '../../components/layouts/Footer';
-import Button from '../../components/@shared/Button';
 import useFetch from '../../hooks/useFetch';
 import Spinner from '../../components/@shared/Spinner';
 import ErrorIcon from '../../components/@shared/ErrorIcon';
-import ModalPortal from '../../components/ModalPortal';
-import ModalWindow from '../../components/@shared/ModalWindow';
 import DivideLine from '../../components/@shared/DivideLine';
 import ReloadButton from '../../components/@shared/ReloadButton';
-import useForm from '../../hooks/useForm';
 import { useParams } from 'react-router-dom';
 import UserItem from '../../components/UserItem';
 
@@ -34,26 +30,6 @@ type MeetingResponseBody = {
   attendanceCount: number;
 };
 
-type FormDataObject = { [k: string]: FormDataEntryValue };
-
-type MeetingStateDataType = {
-  data: MeetingResponseBody;
-  loading: boolean;
-  error: any;
-  fetchingCount: number;
-  refetch: () => void;
-};
-
-const submitAttendanceData = async (url: string, payload: any) => {
-  return fetch(url, {
-    method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(payload),
-  });
-};
-
 const userAttendanceFetch = async (url: string, payload: any) => {
   return fetch(url, {
     method: 'PUT',
@@ -67,61 +43,16 @@ const userAttendanceFetch = async (url: string, payload: any) => {
 const MeetingPage = () => {
   const { id } = useParams();
   const meetingState = useFetch<MeetingResponseBody>(`/meetings/${id}`);
-  const [modalOpened, setModalOpened] = useState(false);
-  const [formData, setFormData] = useState<FormDataObject>();
-  const { isSubmitting, onSubmit, register } = useForm();
 
   const handleChecked = async (
     user: Omit<User, 'accessToken'>,
     checked: boolean
   ) => {
-    const targetMeeting = meetingState.data.users.find(
-      (userData) => userData.id === user.id
-    );
-    targetMeeting.attendanceStatus = checked ? 'present' : 'tardy';
-
-    const response = await userAttendanceFetch(
-      `/meetings/${id}/users/${user.id}`,
-      {
-        attendanceStatus: checked ? 'present' : 'tardy',
-      }
-    );
+    await userAttendanceFetch(`/meetings/${id}/users/${user.id}`, {
+      attendanceStatus: checked ? 'present' : 'tardy',
+    });
 
     meetingState.refetch();
-  };
-
-  const handleOpen = () => {
-    setModalOpened(true);
-  };
-
-  const handleClose = () => {
-    setModalOpened(false);
-  };
-
-  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
-    const target = e.target as HTMLFormElement;
-    const formData = new FormData(target);
-    const formDataObject = Object.fromEntries(formData.entries());
-
-    setFormData(formDataObject);
-
-    handleOpen();
-  };
-
-  const handleConfirm = async () => {
-    const payload = Object.entries(formData).map(([id, value]) => ({
-      id,
-      isAbsent: value === 'absent',
-    }));
-
-    const response = await submitAttendanceData('/meetings/1', payload);
-
-    if (response.ok) {
-      alert('출결 마감했습니다.');
-      handleClose();
-
-      meetingState.refetch();
-    }
   };
 
   if (meetingState.loading) {
@@ -132,11 +63,7 @@ const MeetingPage = () => {
             <Spinner />
           </S.SpinnerBox>
         </S.Layout>
-        <Footer>
-          <Button form="attendance-form" type="submit" disabled>
-            출결 마감
-          </Button>
-        </Footer>
+        <Footer />
       </>
     );
   }
@@ -154,26 +81,13 @@ const MeetingPage = () => {
             />
           </S.ErrorBox>
         </S.Layout>
-        <Footer>
-          <Button form="attendance-form" type="submit" disabled>
-            출결 마감
-          </Button>
-        </Footer>
+        <Footer />
       </>
     );
   }
 
   return (
     <>
-      {modalOpened && (
-        <ModalPortal closePortal={handleClose}>
-          <ModalWindow
-            message="마감하시겠습니까?"
-            onConfirm={handleConfirm}
-            onDismiss={handleClose}
-          />
-        </ModalPortal>
-      )}
       <S.Layout>
         <S.MeetingDetailSection>
           <h2>{meetingState.data.name}</h2>
@@ -183,7 +97,7 @@ const MeetingPage = () => {
         </S.MeetingDetailSection>
         <DivideLine />
         <S.UserListSection>
-          <S.Form id="attendance-form" {...onSubmit(handleSubmit)}>
+          <S.UserListBox>
             <S.UserList>
               {meetingState.data.users.map((user) => (
                 <UserItem
@@ -193,7 +107,7 @@ const MeetingPage = () => {
                 />
               ))}
             </S.UserList>
-          </S.Form>
+          </S.UserListBox>
         </S.UserListSection>
       </S.Layout>
       <Footer />

--- a/frontend/src/pages/MeetingPage/index.tsx
+++ b/frontend/src/pages/MeetingPage/index.tsx
@@ -42,7 +42,12 @@ const userAttendanceFetch = async (url: string, payload: any) => {
 
 const MeetingPage = () => {
   const { id } = useParams();
-  const meetingState = useFetch<MeetingResponseBody>(`/meetings/${id}`);
+  const {
+    data: meetingState,
+    loading: isLoading,
+    error: isError,
+    refetch,
+  } = useFetch<MeetingResponseBody>(`/meetings/${id}`);
 
   const handleChecked = async (
     user: Omit<User, 'accessToken'>,
@@ -52,10 +57,10 @@ const MeetingPage = () => {
       attendanceStatus: checked ? 'present' : 'tardy',
     });
 
-    meetingState.refetch();
+    refetch();
   };
 
-  if (meetingState.loading) {
+  if (isLoading) {
     return (
       <>
         <S.Layout>
@@ -68,7 +73,7 @@ const MeetingPage = () => {
     );
   }
 
-  if (meetingState.error) {
+  if (isError) {
     return (
       <>
         <S.Layout>
@@ -76,7 +81,7 @@ const MeetingPage = () => {
             <ErrorIcon />
             <ReloadButton
               onClick={() => {
-                meetingState.refetch();
+                refetch();
               }}
             />
           </S.ErrorBox>
@@ -90,16 +95,16 @@ const MeetingPage = () => {
     <>
       <S.Layout>
         <S.MeetingDetailSection>
-          <h2>{meetingState.data.name}</h2>
+          <h2>{meetingState.name}</h2>
           <p>
-            총 출석일: <span>{meetingState.data.attendanceCount}</span>
+            총 출석일: <span>{meetingState.attendanceCount}</span>
           </p>
         </S.MeetingDetailSection>
         <DivideLine />
         <S.UserListSection>
           <S.UserListBox>
             <S.UserList>
-              {meetingState.data.users.map((user) => (
+              {meetingState.users.map((user) => (
                 <UserItem
                   key={user.id}
                   user={user}


### PR DESCRIPTION
Close #132 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/fe/user-attendance -> dev

## 요구사항
- 체크박스 클릭시 서버로 데이터 변경 요청
- 출석 여부에 따른 체크박스 UI 변경
- 출석 체크 api mocking
- userItem 및 meeting page 기능 연결

## 변경사항
- meetings mock handler에 출석 체크 api mocking
- 출석 마감 버튼 및 attendance form, modal 제거
- userItem에 체크박스 클릭 핸들러 추가
  - 클릭시 핸들러 인자로 user정보, check상태 전달 
  - checked에 따라 `present`, `tardy` 출석정보를 서버로 데이터 변경 요청
  - 성공했을 경우 다시 데이터를 받아오기 위한 refetch
  - 실패했을 경우 alert

## 논의하고 싶은 내용
Optimistic UI를 적용하려고 시도했지만 현재 상황이
```javascript
const meetingState = useFetch<MeetingResponseBody>(`/meetings/${id}`)
```
로 meeting의 데이터를 받아오고 있고, meeting 데이터를 상태로 가지기 위해 따로 fetch를 구현하기에는 
loading, error를 사용하지 않을 수는 없어서 출석 체크 요청 후 refetch하는 방법을 선택했어요.
react query 같은 경우에는 onMutataion을 옵션을 주고 fetch 함수가 실행되기 전에 실행하는 로직을 받도록 하는데 
이거랑 유사하게 useFetch에 옵션을 추가로 구현하거나, 나중에 query 훅을 만들면서 Optimistic을 적용하는게 어떨까 생각합니다

<br>
<br>



