### PR TITLE
[BE] Interceptor 및 ArgumentResolver 등록 방식 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/auth/config/LoginArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/auth/config/LoginArgumentResolver.java
@@ -5,11 +5,13 @@ import com.woowacourse.auth.support.AuthorizationExtractor;
 import com.woowacourse.auth.support.JwtTokenProvider;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+@Component
 public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/backend/src/main/java/com/woowacourse/auth/config/LoginInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/auth/config/LoginInterceptor.java
@@ -8,9 +8,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+@Component
 public class LoginInterceptor implements HandlerInterceptor {
 
     private final JwtTokenProvider jwtTokenProvider;
@@ -20,7 +22,8 @@ public class LoginInterceptor implements HandlerInterceptor {
     }
 
     @Override
-    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response,
+    public boolean preHandle(final HttpServletRequest request,
+                             final HttpServletResponse response,
                              final Object handler) {
         if (request.getMethod().equals((HttpMethod.OPTIONS.name()))) {
             return true;
@@ -30,7 +33,7 @@ public class LoginInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        if (!isValidateToken(request)) {
+        if (!isValidToken(request)) {
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
             return false;
         }
@@ -44,7 +47,7 @@ public class LoginInterceptor implements HandlerInterceptor {
         return Objects.isNull(classAnnotation) && Objects.isNull(methodAnnotation);
     }
 
-    private boolean isValidateToken(final HttpServletRequest request) {
+    private boolean isValidToken(final HttpServletRequest request) {
         final String token = AuthorizationExtractor.extract(request);
         return jwtTokenProvider.validateToken(token);
     }

--- a/backend/src/main/java/com/woowacourse/auth/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/auth/config/WebConfig.java
@@ -1,41 +1,33 @@
 package com.woowacourse.auth.config;
 
-import com.woowacourse.auth.support.JwtTokenProvider;
 import java.util.List;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    private final JwtTokenProvider jwtTokenProvider;
+    private final List<HandlerInterceptor> interceptors;
+    private final List<HandlerMethodArgumentResolver> resolvers;
 
-    public WebConfig(final JwtTokenProvider jwtTokenProvider) {
-        this.jwtTokenProvider = jwtTokenProvider;
+    public WebConfig(final List<HandlerInterceptor> interceptors,
+                     final List<HandlerMethodArgumentResolver> resolvers) {
+        this.interceptors = interceptors;
+        this.resolvers = resolvers;
     }
+
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
-        final LoginInterceptor interceptor = loginInterceptor();
-        registry.addInterceptor(interceptor)
-                .addPathPatterns("/**");
+        interceptors.forEach(interceptor -> registry.addInterceptor(interceptor)
+                .addPathPatterns("/**"));
     }
 
     @Override
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(loginArgumentResolver());
-    }
-
-    @Bean
-    public LoginInterceptor loginInterceptor() {
-        return new LoginInterceptor(jwtTokenProvider);
-    }
-
-    @Bean
-    public LoginArgumentResolver loginArgumentResolver() {
-        return new LoginArgumentResolver(jwtTokenProvider);
+        resolvers.addAll(this.resolvers);
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/ControllerAdvice.java
@@ -7,6 +7,7 @@ import com.woowacourse.auth.exception.LoginFailException;
 import com.woowacourse.moragora.dto.ErrorResponse;
 import com.woowacourse.moragora.exception.InvalidFormatException;
 import com.woowacourse.moragora.exception.MeetingNotFoundException;
+import com.woowacourse.moragora.exception.NoKeywordException;
 import com.woowacourse.moragora.exception.meeting.IllegalStartEndDateException;
 import java.util.List;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -56,6 +57,12 @@ public class ControllerAdvice {
     @ExceptionHandler(LoginFailException.class)
     @ResponseStatus(BAD_REQUEST)
     public ErrorResponse handleLoginFailException(final Exception exception) {
+        return new ErrorResponse(exception.getMessage());
+    }
+
+    @ExceptionHandler(NoKeywordException.class)
+    @ResponseStatus(BAD_REQUEST)
+    public ErrorResponse handleNoKeywordException(final Exception exception) {
         return new ErrorResponse(exception.getMessage());
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/controller/UserController.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/UserController.java
@@ -1,13 +1,16 @@
 package com.woowacourse.moragora.controller;
 
+import com.woowacourse.moragora.dto.SearchedUsersResponse;
 import com.woowacourse.moragora.dto.UserRequest;
 import com.woowacourse.moragora.service.UserService;
 import java.net.URI;
 import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,5 +27,11 @@ public class UserController {
     public ResponseEntity<Void> signUp(@RequestBody @Valid final UserRequest userRequest) {
         final Long id = userService.create(userRequest);
         return ResponseEntity.created(URI.create("/users/" + id)).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<SearchedUsersResponse> search(@RequestParam final String keyword) {
+        final SearchedUsersResponse response = userService.searchByKeyword(keyword);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/SearchedUserResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/SearchedUserResponse.java
@@ -1,0 +1,22 @@
+package com.woowacourse.moragora.dto;
+
+import com.woowacourse.moragora.entity.user.User;
+import lombok.Getter;
+
+@Getter
+public class SearchedUserResponse {
+
+    private final Long id;
+    private final String email;
+    private final String nickname;
+
+    public SearchedUserResponse(final Long id, final String email, final String nickname) {
+        this.id = id;
+        this.email = email;
+        this.nickname = nickname;
+    }
+
+    public static SearchedUserResponse from(final User user) {
+        return new SearchedUserResponse(user.getId(), user.getEmail(), user.getNickname());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/moragora/dto/SearchedUsersResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/SearchedUsersResponse.java
@@ -1,0 +1,14 @@
+package com.woowacourse.moragora.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class SearchedUsersResponse {
+
+    private final List<SearchedUserResponse> users;
+
+    public SearchedUsersResponse(final List<SearchedUserResponse> users) {
+        this.users = users;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/moragora/exception/NoKeywordException.java
+++ b/backend/src/main/java/com/woowacourse/moragora/exception/NoKeywordException.java
@@ -1,0 +1,10 @@
+package com.woowacourse.moragora.exception;
+
+public class NoKeywordException extends RuntimeException {
+
+    private static final String MESSAGE = "검색어가 입력되지 않았습니다.";
+
+    public NoKeywordException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/moragora/repository/UserRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/repository/UserRepository.java
@@ -47,4 +47,11 @@ public class UserRepository {
         final User user = entityManager.find(User.class, userId);
         return Optional.ofNullable(user);
     }
+
+    public List<User> findByNicknameOrEmailContaining(final String keyword) {
+        return entityManager.createQuery(
+                "select u from User u where u.email like :keyword or u.nickname like :keyword", User.class)
+                .setParameter("keyword", "%" + keyword + "%")
+                .getResultList();
+    }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/service/UserService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/UserService.java
@@ -1,9 +1,14 @@
 package com.woowacourse.moragora.service;
 
+import com.woowacourse.moragora.dto.SearchedUserResponse;
+import com.woowacourse.moragora.dto.SearchedUsersResponse;
 import com.woowacourse.moragora.dto.UserRequest;
 import com.woowacourse.moragora.entity.user.EncodedPassword;
 import com.woowacourse.moragora.entity.user.User;
+import com.woowacourse.moragora.exception.NoKeywordException;
 import com.woowacourse.moragora.repository.UserRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,5 +27,20 @@ public class UserService {
                 userRequest.getNickname());
         final User savedUser = userRepository.save(user);
         return savedUser.getId();
+    }
+
+    public SearchedUsersResponse searchByKeyword(final String keyword) {
+        validateKeyword(keyword);
+        final List<User> searchedUsers = userRepository.findByNicknameOrEmailContaining(keyword);
+        final List<SearchedUserResponse> responses = searchedUsers.stream()
+                .map(SearchedUserResponse::from)
+                .collect(Collectors.toList());
+        return new SearchedUsersResponse(responses);
+    }
+
+    private void validateKeyword(final String keyword) {
+        if (keyword.isEmpty()) {
+            throw new NoKeywordException();
+        }
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/UserAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/UserAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.moragora.acceptance;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.notNullValue;
 
 import com.woowacourse.moragora.dto.UserRequest;
@@ -23,5 +24,28 @@ public class UserAcceptanceTest extends AcceptanceTest {
         // then
         response.statusCode(HttpStatus.CREATED.value())
                 .header("Location", notNullValue());
+    }
+
+    @DisplayName("키워드를 입력하면 그 키워드가 포함된 유저 목록과 상태코드 200을 반환한다.")
+    @Test
+    void search() {
+        // given
+        final String keyword = "foo";
+
+        // when
+        final ValidatableResponse response = get("/users?keyword=" + keyword);
+
+        // then
+        response.statusCode(HttpStatus.OK.value())
+                .body("users.id", containsInAnyOrder(1, 2, 3, 4, 5, 6, 7))
+                .body("users.nickname", containsInAnyOrder("아스피", "필즈", "포키",
+                        "썬", "우디", "쿤", "반듯"))
+                .body("users.email", containsInAnyOrder("aaa111@foo.com",
+                        "bbb222@foo.com",
+                        "ccc333@foo.com",
+                        "ddd444@foo.com",
+                        "eee555@foo.com",
+                        "fff666@foo.com",
+                        "ggg777@foo.com"));
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
@@ -3,7 +3,6 @@ package com.woowacourse.moragora.controller;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -13,7 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.auth.config.WebConfig;
+import com.woowacourse.auth.support.JwtTokenProvider;
 import com.woowacourse.moragora.dto.MeetingRequest;
 import com.woowacourse.moragora.dto.MeetingResponse;
 import com.woowacourse.moragora.dto.UserResponse;
@@ -36,9 +35,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-// TODO: LoginArgumentResolver return mocking 시도
 @WebMvcTest(controllers = {MeetingController.class})
-@MockBean(value = {WebConfig.class})
 class MeetingControllerTest {
 
     @Autowired
@@ -49,6 +46,9 @@ class MeetingControllerTest {
 
     @MockBean
     private MeetingService meetingService;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
 
     @DisplayName("미팅 방을 생성한다.")
     @Test
@@ -64,7 +64,11 @@ class MeetingControllerTest {
         );
 
         // when
-        given(meetingService.save(any(MeetingRequest.class), nullable(Long.class)))
+        given(jwtTokenProvider.validateToken(any()))
+                .willReturn(true);
+        given(jwtTokenProvider.getPayload(any()))
+                .willReturn("1");
+        given(meetingService.save(any(MeetingRequest.class), eq(1L)))
                 .willReturn(1L);
 
         // then
@@ -90,7 +94,11 @@ class MeetingControllerTest {
         );
 
         // when
-        given(meetingService.save(any(MeetingRequest.class), nullable(Long.class)))
+        given(jwtTokenProvider.validateToken(any()))
+                .willReturn(true);
+        given(jwtTokenProvider.getPayload(any()))
+                .willReturn("1");
+        given(meetingService.save(any(MeetingRequest.class), eq(1L)))
                 .willThrow(new IllegalStartEndDateException());
 
         // then
@@ -119,7 +127,13 @@ class MeetingControllerTest {
                 List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L)
         );
 
-        // when, then
+        // when
+        given(jwtTokenProvider.validateToken(any()))
+                .willReturn(true);
+        given(jwtTokenProvider.getPayload(any()))
+                .willReturn("1");
+
+        // then
         mockMvc.perform(post("/meetings")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(meetingRequest)))
@@ -149,7 +163,13 @@ class MeetingControllerTest {
         params.put("entranceTime", entranceTime);
         params.put("leaveTime", leaveTime);
 
-        // when, then
+        // when
+        given(jwtTokenProvider.validateToken(any()))
+                .willReturn(true);
+        given(jwtTokenProvider.getPayload(any()))
+                .willReturn("1");
+
+        // then
         mockMvc.perform(post("/meetings")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(params)))
@@ -180,7 +200,11 @@ class MeetingControllerTest {
         );
 
         // when
-        given(meetingService.findById(eq(1L), nullable(Long.class)))
+        given(jwtTokenProvider.validateToken(any()))
+                .willReturn(true);
+        given(jwtTokenProvider.getPayload(any()))
+                .willReturn("1");
+        given(meetingService.findById(eq(1L), eq(1L)))
                 .willReturn(meetingResponse);
 
         // then

--- a/backend/src/test/java/com/woowacourse/moragora/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/UserControllerTest.java
@@ -12,7 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.auth.config.WebConfig;
+import com.woowacourse.auth.support.JwtTokenProvider;
 import com.woowacourse.moragora.dto.SearchedUserResponse;
 import com.woowacourse.moragora.dto.SearchedUsersResponse;
 import com.woowacourse.moragora.dto.UserRequest;
@@ -30,7 +30,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = {UserController.class})
-@MockBean(value = {WebConfig.class})
 public class UserControllerTest {
 
     @Autowired
@@ -42,6 +41,9 @@ public class UserControllerTest {
     @MockBean
     private UserService userService;
 
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
     @DisplayName("회원가입에 성공한다.")
     @Test
     void signUp() throws Exception {
@@ -50,10 +52,16 @@ public class UserControllerTest {
         given(userService.create(any(UserRequest.class)))
                 .willReturn(1L);
 
-        // when, then
+        // when
+        given(jwtTokenProvider.validateToken(any()))
+                .willReturn(true);
+        given(jwtTokenProvider.getPayload(any()))
+                .willReturn("1");
+
+        // then
         mockMvc.perform(post("/users")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(userRequest)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(userRequest)))
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", equalTo("/users/" + 1)));
@@ -77,10 +85,16 @@ public class UserControllerTest {
         // given
         final UserRequest userRequest = new UserRequest(email, password, nickname);
 
-        // when, then
+        // when
+        given(jwtTokenProvider.validateToken(any()))
+                .willReturn(true);
+        given(jwtTokenProvider.getPayload(any()))
+                .willReturn("1");
+
+        // then
         mockMvc.perform(post("/users")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(userRequest)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(userRequest)))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("message")
@@ -106,7 +120,7 @@ public class UserControllerTest {
 
         // when, then
         mockMvc.perform(get("/users?keyword=" + keyword)
-                .accept(MediaType.APPLICATION_JSON))
+                        .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.users[*].id", containsInAnyOrder(1, 2, 3, 4, 5, 6, 7)))
@@ -132,7 +146,7 @@ public class UserControllerTest {
 
         // when, then
         mockMvc.perform(get("/users?keyword=" + keyword)
-                .accept(MediaType.APPLICATION_JSON))
+                        .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message", equalTo("검색어가 입력되지 않았습니다.")));

--- a/backend/src/test/java/com/woowacourse/moragora/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/UserControllerTest.java
@@ -1,8 +1,10 @@
 package com.woowacourse.moragora.controller;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -11,8 +13,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.auth.config.WebConfig;
+import com.woowacourse.moragora.dto.SearchedUserResponse;
+import com.woowacourse.moragora.dto.SearchedUsersResponse;
 import com.woowacourse.moragora.dto.UserRequest;
+import com.woowacourse.moragora.exception.NoKeywordException;
 import com.woowacourse.moragora.service.UserService;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -46,8 +52,8 @@ public class UserControllerTest {
 
         // when, then
         mockMvc.perform(post("/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(userRequest)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userRequest)))
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", equalTo("/users/" + 1)));
@@ -73,11 +79,62 @@ public class UserControllerTest {
 
         // when, then
         mockMvc.perform(post("/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(userRequest)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userRequest)))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("message")
                         .value("입력 형식이 올바르지 않습니다."));
+    }
+
+    @DisplayName("keyword로 유저를 검색해 반환한다.")
+    @Test
+    void search() throws Exception {
+        // given
+        final String keyword = "foo";
+        given(userService.searchByKeyword(keyword))
+                .willReturn(new SearchedUsersResponse(
+                        List.of(
+                                new SearchedUserResponse(1L, "aaa111@foo.com", "아스피"),
+                                new SearchedUserResponse(2L, "bbb222@foo.com", "필즈"),
+                                new SearchedUserResponse(3L, "ccc333@foo.com", "포키"),
+                                new SearchedUserResponse(4L, "ddd444@foo.com", "썬"),
+                                new SearchedUserResponse(5L, "eee555@foo.com", "우디"),
+                                new SearchedUserResponse(6L, "fff666@foo.com", "쿤"),
+                                new SearchedUserResponse(7L, "ggg777@foo.com", "반듯"))
+                ));
+
+        // when, then
+        mockMvc.perform(get("/users?keyword=" + keyword)
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.users[*].id", containsInAnyOrder(1, 2, 3, 4, 5, 6, 7)))
+                .andExpect(jsonPath("$.users[*].email", containsInAnyOrder(
+                        "aaa111@foo.com",
+                        "bbb222@foo.com",
+                        "ccc333@foo.com",
+                        "ddd444@foo.com",
+                        "eee555@foo.com",
+                        "fff666@foo.com",
+                        "ggg777@foo.com")))
+                .andExpect(jsonPath("$.users[*].nickname", containsInAnyOrder(
+                        "아스피", "필즈", "포키", "썬", "우디", "쿤", "반듯")));
+    }
+
+    @DisplayName("keyword를 입력하지 않고 검색하면 예외가 발생한다.")
+    @Test
+    void search_throwsException_ifNoKeyword() throws Exception {
+        // given
+        final String keyword = "";
+        given(userService.searchByKeyword(keyword))
+                .willThrow(new NoKeywordException());
+
+        // when, then
+        mockMvc.perform(get("/users?keyword=" + keyword)
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message", equalTo("검색어가 입력되지 않았습니다.")));
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/repository/UserRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/repository/UserRepositoryTest.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,5 +55,16 @@ class UserRepositoryTest {
 
         // then
         assertThat(user.isPresent()).isTrue();
+    }
+
+    @DisplayName("keyword로 유저를 검색할 수 있다.")
+    @ParameterizedTest
+    @CsvSource(value = {"foo,7", "ggg777@foo.com,1"})
+    void findByNicknameOrEmailContaining(final String keyword, final int expectedSize) {
+        // given, when
+        final List<User> users = userRepository.findByNicknameOrEmailContaining(keyword);
+
+        // then
+        assertThat(users).hasSize(expectedSize);
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/service/UserServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/UserServiceTest.java
@@ -1,8 +1,11 @@
 package com.woowacourse.moragora.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.moragora.dto.SearchedUsersResponse;
 import com.woowacourse.moragora.dto.UserRequest;
+import com.woowacourse.moragora.exception.NoKeywordException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,5 +30,26 @@ class UserServiceTest {
 
         // then
         assertThat(id).isNotNull();
+    }
+
+    @DisplayName("keyword로 회원을 검색한다.")
+    @Test
+    void searchByKeyword() {
+        // given
+        final String keyword = "foo";
+
+        // when
+        final SearchedUsersResponse response = userService.searchByKeyword(keyword);
+
+        // then
+        assertThat(response.getUsers()).hasSize(7);
+    }
+
+    @DisplayName("keyword를 입력하지 않고 검색하면 예외가 발생한다.")
+    @Test
+    void searchByKeyword_throwsException_ifNoKeyword() {
+        // given, when, then
+        assertThatThrownBy(() -> userService.searchByKeyword(""))
+                .isInstanceOf(NoKeywordException.class);
     }
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 기능 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
ex) feature/be/auth-bean -> dev

## 요구사항
수동 빈 등록에서 자동 빈 등록으로 변경한다.

## 변경사항
`LoginInterceptor`와 `LoginArgumentResolver`를 @Component 어노테이션을 이용해 등록되도록 수정.

