### PR TITLE
[BE] Controller Test 동일한 환경을 위한 상위 클래스 분리 

### DIFF
--- a/backend/src/test/java/com/woowacourse/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/auth/controller/AuthControllerTest.java
@@ -2,37 +2,18 @@ package com.woowacourse.auth.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.auth.dto.LoginRequest;
 import com.woowacourse.auth.dto.LoginResponse;
 import com.woowacourse.auth.exception.LoginFailException;
-import com.woowacourse.auth.service.AuthService;
-import com.woowacourse.auth.support.JwtTokenProvider;
+import com.woowacourse.moragora.controller.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
-@WebMvcTest(controllers = {AuthController.class})
-@MockBean(value = {JwtTokenProvider.class})
-public class AuthControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @MockBean
-    private AuthService authService;
+public class AuthControllerTest extends ControllerTest {
 
     @DisplayName("로그인에 성공한다.")
     @Test
@@ -44,12 +25,11 @@ public class AuthControllerTest {
         given(authService.createToken(any(LoginRequest.class)))
                 .willReturn(new LoginResponse(accessToken));
 
-        // when, then
-        mockMvc.perform(post("/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequest)))
-                .andDo(print())
-                .andExpect(status().isOk())
+        // when
+        final ResultActions resultActions = performPost("/login", loginRequest);
+
+        // then
+        resultActions.andExpect(status().isOk())
                 .andExpect(jsonPath("accessToken").value(accessToken));
     }
 
@@ -62,12 +42,11 @@ public class AuthControllerTest {
         given(authService.createToken(any(LoginRequest.class)))
                 .willThrow(new LoginFailException());
 
-        // when, then
-        mockMvc.perform(post("/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequest)))
-                .andDo(print())
-                .andExpect(status().isBadRequest())
+        // when
+        final ResultActions resultActions = performPost("/login", loginRequest);
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("message").value("이메일이나 비밀번호가 틀렸습니다."));
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/controller/ControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/ControllerTest.java
@@ -1,5 +1,7 @@
 package com.woowacourse.moragora.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
@@ -56,5 +58,13 @@ public class ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print());
+    }
+
+    protected Long validateToken(String id) {
+        given(jwtTokenProvider.validateToken(any()))
+                .willReturn(true);
+        given(jwtTokenProvider.getPayload(any()))
+                .willReturn(id);
+        return Long.valueOf(id);
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/controller/ControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/ControllerTest.java
@@ -1,0 +1,60 @@
+package com.woowacourse.moragora.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.auth.controller.AuthController;
+import com.woowacourse.auth.service.AuthService;
+import com.woowacourse.auth.support.JwtTokenProvider;
+import com.woowacourse.moragora.service.MeetingService;
+import com.woowacourse.moragora.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest(controllers = {MeetingController.class, UserController.class, AuthController.class})
+public class ControllerTest {
+
+    @MockBean
+    protected AuthService authService;
+
+    @MockBean
+    protected MeetingService meetingService;
+
+    @MockBean
+    protected UserService userService;
+
+    @MockBean
+    protected JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    protected ResultActions performPost(final String uri, final Object request) throws Exception {
+        return mockMvc.perform(post(uri)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print());
+    }
+
+    protected ResultActions performGet(final String uri) throws Exception {
+        return mockMvc.perform(MockMvcRequestBuilders.get(uri)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print());
+    }
+
+    protected ResultActions performPut(final String uri, final Object request) throws Exception {
+        return mockMvc.perform(MockMvcRequestBuilders.put(uri)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print());
+    }
+}

--- a/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
@@ -46,11 +46,8 @@ class MeetingControllerTest extends ControllerTest {
                 List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L)
         );
 
-        given(jwtTokenProvider.validateToken(any()))
-                .willReturn(true);
-        given(jwtTokenProvider.getPayload(any()))
-                .willReturn("1");
-        given(meetingService.save(any(MeetingRequest.class), eq(1L)))
+        final Long loginId = validateToken("1");
+        given(meetingService.save(any(MeetingRequest.class), eq(loginId)))
                 .willReturn(1L);
         // when
         final ResultActions resultActions = performPost("/meetings", meetingRequest);
@@ -73,11 +70,8 @@ class MeetingControllerTest extends ControllerTest {
                 List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L)
         );
 
-        given(jwtTokenProvider.validateToken(any()))
-                .willReturn(true);
-        given(jwtTokenProvider.getPayload(any()))
-                .willReturn("1");
-        given(meetingService.save(any(MeetingRequest.class), eq(1L)))
+        final Long loginId = validateToken("1");
+        given(meetingService.save(any(MeetingRequest.class), eq(loginId)))
                 .willThrow(new IllegalStartEndDateException());
 
         // when
@@ -105,10 +99,7 @@ class MeetingControllerTest extends ControllerTest {
                 List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L)
         );
 
-        given(jwtTokenProvider.validateToken(any()))
-                .willReturn(true);
-        given(jwtTokenProvider.getPayload(any()))
-                .willReturn("1");
+        validateToken("1");
 
         // when
         final ResultActions resultActions = performPost("/meetings", meetingRequest);
@@ -139,10 +130,7 @@ class MeetingControllerTest extends ControllerTest {
         params.put("entranceTime", entranceTime);
         params.put("leaveTime", leaveTime);
 
-        given(jwtTokenProvider.validateToken(any()))
-                .willReturn(true);
-        given(jwtTokenProvider.getPayload(any()))
-                .willReturn("1");
+        validateToken("1");
 
         // when
         final ResultActions resultActions = performPost("/meetings", params);
@@ -173,11 +161,8 @@ class MeetingControllerTest extends ControllerTest {
                 usersResponse
         );
 
-        given(jwtTokenProvider.validateToken(any()))
-                .willReturn(true);
-        given(jwtTokenProvider.getPayload(any()))
-                .willReturn("1");
-        given(meetingService.findById(eq(1L), eq(1L)))
+        final Long loginId = validateToken("1");
+        given(meetingService.findById(eq(1L), eq(loginId)))
                 .willReturn(meetingResponse);
 
         // when
@@ -202,10 +187,7 @@ class MeetingControllerTest extends ControllerTest {
         final Long userId = 1L;
         final UserAttendanceRequest request = new UserAttendanceRequest(Status.PRESENT);
 
-        given(jwtTokenProvider.validateToken(any()))
-                .willReturn(true);
-        given(jwtTokenProvider.getPayload(any()))
-                .willReturn("1");
+        validateToken("1");
 
         // when
         final ResultActions resultActions = performPut("/meetings/" + meetingId + "/users/" + userId, request);
@@ -222,14 +204,11 @@ class MeetingControllerTest extends ControllerTest {
         final Long userId = 1L;
         final UserAttendanceRequest request = new UserAttendanceRequest(Status.PRESENT);
 
-        given(jwtTokenProvider.validateToken(any()))
-                .willReturn(true);
-        given(jwtTokenProvider.getPayload(any()))
-                .willReturn("1");
+        final Long loginId = validateToken("1");
 
         doThrow(MeetingNotFoundException.class)
                 .when(meetingService)
-                .updateAttendance(anyLong(), anyLong(), any(UserAttendanceRequest.class), eq(1L));
+                .updateAttendance(anyLong(), anyLong(), any(UserAttendanceRequest.class), eq(loginId));
 
         // when
         final ResultActions resultActions = performPut("/meetings/" + meetingId + "/users/" + userId, request);
@@ -246,14 +225,11 @@ class MeetingControllerTest extends ControllerTest {
         final Long userId = 8L;
         final UserAttendanceRequest request = new UserAttendanceRequest(Status.PRESENT);
 
-        given(jwtTokenProvider.validateToken(any()))
-                .willReturn(true);
-        given(jwtTokenProvider.getPayload(any()))
-                .willReturn("1");
+        final Long loginId = validateToken("1");
 
         doThrow(ParticipantNotFoundException.class)
                 .when(meetingService)
-                .updateAttendance(anyLong(), anyLong(), any(UserAttendanceRequest.class), eq(1L));
+                .updateAttendance(anyLong(), anyLong(), any(UserAttendanceRequest.class), eq(loginId));
 
         // when
         final ResultActions resultActions = performPut("/meetings/" + meetingId + "/users/" + userId, request);

--- a/backend/src/test/java/com/woowacourse/moragora/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/UserControllerTest.java
@@ -32,10 +32,8 @@ public class UserControllerTest extends ControllerTest {
         final UserRequest userRequest = new UserRequest("kun@naver.com", "1234smart!", "kun");
         given(userService.create(any(UserRequest.class)))
                 .willReturn(1L);
-        given(jwtTokenProvider.validateToken(any()))
-                .willReturn(true);
-        given(jwtTokenProvider.getPayload(any()))
-                .willReturn("1");
+
+        validateToken("1");
 
         // when
         final ResultActions resultActions = performPost("/users", userRequest);
@@ -63,10 +61,7 @@ public class UserControllerTest extends ControllerTest {
         // given
         final UserRequest userRequest = new UserRequest(email, password, nickname);
 
-        given(jwtTokenProvider.validateToken(any()))
-                .willReturn(true);
-        given(jwtTokenProvider.getPayload(any()))
-                .willReturn("1");
+        validateToken("1");
 
         // when
         final ResultActions resultActions = performPost("/users", userRequest);


### PR DESCRIPTION
Close #147 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/controllertest-structure -> dev

## 요구사항

## 변경사항
- 모든 ControllerTest 클래스가 실행할 때 스프링 컨테이너를 한 번만 띄우게 하기 위해 상위 클래스에서 환경 설정을 한다.
- mockMvc의 post, get, put 같은 메서드를 분리하여 코드의 반복을 줄인다.

## [Optional] 논의하고 싶은 내용

<!--Close #issue_number를 작성한다.-->

