### PR TITLE
[BE] 로그인한 회원의 참가 meeting 목록 조회 url 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/moragora/controller/MeetingController.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/MeetingController.java
@@ -43,7 +43,7 @@ public class MeetingController {
         return ResponseEntity.ok(meetingResponse);
     }
 
-    @GetMapping
+    @GetMapping("/me")
     public ResponseEntity<MyMeetingsResponse> findMy(@AuthenticationPrincipal final Long id) {
         final MyMeetingsResponse meetingsResponse = meetingService.findAllByUserId(id);
         return ResponseEntity.ok(meetingsResponse);

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
@@ -96,7 +96,7 @@ public class MeetingAcceptanceTest extends AcceptanceTest {
         post("/meetings", meetingRequest2, token);
 
         // when
-        final ValidatableResponse response = get("/meetings", token);
+        final ValidatableResponse response = get("/meetings/me", token);
 
         // then
         response.statusCode(HttpStatus.OK.value())

--- a/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
@@ -317,7 +317,7 @@ class MeetingControllerTest extends ControllerTest {
                 .willReturn(meetingsResponse);
 
         // then
-        performGet("/meetings")
+        performGet("/meetings/me")
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.serverTime", is("10:01:00")))
                 .andExpect(jsonPath("$.meetings[*].name", containsInAnyOrder("모임1", "모임2")))


### PR DESCRIPTION
Close #157 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
hotfix/be/find-my-meetings -> dev

## 요구사항
- `GET /meetings/me`에 참가 모임 목록 조회 mapping

## 변경사항
- controller handler 및 Acceptance Test, Controller Test에서 url 수정

<!--Close #issue_number를 작성한다.-->

