### PR TITLE
[BE] 서버시간 응답 형식 Timestamp로 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/moragora/dto/MyMeetingsResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/MyMeetingsResponse.java
@@ -14,8 +14,8 @@ public class MyMeetingsResponse {
     private final long serverTime;
     private final List<MyMeetingResponse> meetings;
 
-    private MyMeetingsResponse(final LocalDateTime serverTime, final List<MyMeetingResponse> meetings) {
-        this.serverTime = Timestamp.valueOf(serverTime).getTime();
+    private MyMeetingsResponse(final long serverTime, final List<MyMeetingResponse> meetings) {
+        this.serverTime = serverTime;
         this.meetings = meetings;
     }
 
@@ -26,6 +26,10 @@ public class MyMeetingsResponse {
                 .map(meeting -> MyMeetingResponse.of(now.toLocalTime(), timeChecker, meeting))
                 .collect(Collectors.toList());
 
-        return new MyMeetingsResponse(now, myMeetingResponses);
+        return new MyMeetingsResponse(toTimestamp(now), myMeetingResponses);
+    }
+
+    private static long toTimestamp(final LocalDateTime now) {
+        return Timestamp.valueOf(now).getTime();
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/MyMeetingsResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/MyMeetingsResponse.java
@@ -2,7 +2,8 @@ package com.woowacourse.moragora.dto;
 
 import com.woowacourse.moragora.entity.Meeting;
 import com.woowacourse.moragora.service.closingstrategy.TimeChecker;
-import java.time.LocalTime;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Getter;
@@ -10,19 +11,19 @@ import lombok.Getter;
 @Getter
 public class MyMeetingsResponse {
 
-    private final LocalTime serverTime;
+    private final long serverTime;
     private final List<MyMeetingResponse> meetings;
 
-    private MyMeetingsResponse(final LocalTime serverTime, final List<MyMeetingResponse> meetings) {
-        this.serverTime = serverTime;
+    private MyMeetingsResponse(final LocalDateTime serverTime, final List<MyMeetingResponse> meetings) {
+        this.serverTime = Timestamp.valueOf(serverTime).getTime();
         this.meetings = meetings;
     }
 
-    public static MyMeetingsResponse of(final LocalTime now,
+    public static MyMeetingsResponse of(final LocalDateTime now,
                                         final TimeChecker timeChecker,
                                         final List<Meeting> meetings) {
         final List<MyMeetingResponse> myMeetingResponses = meetings.stream()
-                .map(meeting -> MyMeetingResponse.of(now, timeChecker, meeting))
+                .map(meeting -> MyMeetingResponse.of(now.toLocalTime(), timeChecker, meeting))
                 .collect(Collectors.toList());
 
         return new MyMeetingsResponse(now, myMeetingResponses);

--- a/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
@@ -101,7 +101,7 @@ public class MeetingService {
     }
 
     public MyMeetingsResponse findAllByUserId(final Long userId) {
-        final LocalTime now = LocalTime.now();
+        final LocalDateTime now = LocalDateTime.now();
         final List<Participant> participants = participantRepository.findByUserId(userId);
         final List<Meeting> meetings = participants.stream()
                 .map(Participant::getMeeting)

--- a/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
@@ -25,7 +25,9 @@ import com.woowacourse.moragora.exception.MeetingNotFoundException;
 import com.woowacourse.moragora.exception.ParticipantNotFoundException;
 import com.woowacourse.moragora.exception.UserNotFoundException;
 import com.woowacourse.moragora.exception.meeting.IllegalStartEndDateException;
+import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -304,7 +306,7 @@ class MeetingControllerTest extends ControllerTest {
                 LocalTime.of(9, 0),
                 LocalTime.of(9, 5)
         );
-        final LocalTime now = LocalTime.of(10, 1);
+        final LocalDateTime now = LocalTime.of(10, 1).atDate(LocalDate.now());
         final MyMeetingsResponse meetingsResponse = MyMeetingsResponse.of(now, new FakeTimeChecker(),
                 List.of(meeting1, meeting2));
 
@@ -319,7 +321,7 @@ class MeetingControllerTest extends ControllerTest {
         // then
         performGet("/meetings/me")
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.serverTime", is("10:01:00")))
+                .andExpect(jsonPath("$.serverTime", is(Timestamp.valueOf(now).getTime())))
                 .andExpect(jsonPath("$.meetings[*].name", containsInAnyOrder("모임1", "모임2")))
                 .andExpect(jsonPath("$.meetings[*].active", containsInAnyOrder(true, true)))
                 .andExpect(jsonPath("$.meetings[*].startDate", containsInAnyOrder("2022-07-10", "2022-07-15")))

--- a/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
@@ -225,7 +225,7 @@ class MeetingServiceTest {
         assertThat(myMeetingsResponse).usingRecursiveComparison()
                 .ignoringFields("serverTime", "meetings.id")
                 .isEqualTo(MyMeetingsResponse.of(
-                        LocalTime.now(),
+                        LocalDateTime.now(),
                         timeChecker,
                         List.of(meeting, meetingRequest.toEntity()))
                 );


### PR DESCRIPTION
Close #170 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/servertime-formatting -> dev

## 요구사항
- 로그인한 회원의 참가 미팅 목록 조회 시 서버시간 `Timestamp`로 응답

## 변경사항

<!--Close #issue_number를 작성한다.-->

