### PR TITLE
[BE] 유저별 참여 모임 전체 조회 API 변경 반영

### DIFF
--- a/backend/src/main/java/com/woowacourse/ApplicationStartupRunner.java
+++ b/backend/src/main/java/com/woowacourse/ApplicationStartupRunner.java
@@ -77,7 +77,7 @@ public class ApplicationStartupRunner implements ApplicationListener<ContextRefr
         participantRepository.save(participant6);
         participantRepository.save(participant7);
 
-        final Attendance attendance1 = new Attendance(participant1, LocalDate.of(2022, 7, 12), Status.PRESENT);
+        final Attendance attendance1 = new Attendance(participant1, LocalDate.of(2022, 7, 12), Status.TARDY);
         final Attendance attendance2 = new Attendance(participant2, LocalDate.of(2022, 7, 12), Status.TARDY);
         final Attendance attendance3 = new Attendance(participant3, LocalDate.of(2022, 7, 12), Status.PRESENT);
         final Attendance attendance4 = new Attendance(participant4, LocalDate.of(2022, 7, 12), Status.PRESENT);

--- a/backend/src/main/java/com/woowacourse/moragora/dto/MyMeetingResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/MyMeetingResponse.java
@@ -19,6 +19,7 @@ public class MyMeetingResponse {
     private final LocalDate endDate;
     private final String entranceTime;
     private final String closingTime;
+    private final int tardyCount;
 
     public MyMeetingResponse(final Long id,
                              final String name,
@@ -26,7 +27,8 @@ public class MyMeetingResponse {
                              final LocalDate startDate,
                              final LocalDate endDate,
                              final LocalTime entranceTime,
-                             final LocalTime closingTime) {
+                             final LocalTime closingTime,
+                             final int tardyCount) {
         this.id = id;
         this.name = name;
         this.isActive = isActive;
@@ -34,9 +36,13 @@ public class MyMeetingResponse {
         this.endDate = endDate;
         this.entranceTime = entranceTime.format(TIME_FORMATTER);
         this.closingTime = closingTime.format(TIME_FORMATTER);
+        this.tardyCount = tardyCount;
     }
 
-    public static MyMeetingResponse of(final LocalTime now, final TimeChecker timeChecker, final Meeting meeting) {
+    public static MyMeetingResponse of(final LocalTime now,
+                                       final TimeChecker timeChecker,
+                                       final Meeting meeting,
+                                       final int tardyCount) {
 
         return new MyMeetingResponse(
                 meeting.getId(),
@@ -45,7 +51,9 @@ public class MyMeetingResponse {
                 meeting.getStartDate(),
                 meeting.getEndDate(),
                 meeting.getEntranceTime(),
-                timeChecker.calculateClosingTime(meeting.getEntranceTime())
+                timeChecker.calculateClosingTime(meeting.getEntranceTime()),
+                tardyCount
         );
     }
+
 }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/MyMeetingsResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/MyMeetingsResponse.java
@@ -1,11 +1,8 @@
 package com.woowacourse.moragora.dto;
 
-import com.woowacourse.moragora.entity.Meeting;
-import com.woowacourse.moragora.service.closingstrategy.TimeChecker;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Getter;
 
 @Getter
@@ -14,19 +11,13 @@ public class MyMeetingsResponse {
     private final long serverTime;
     private final List<MyMeetingResponse> meetings;
 
-    public MyMeetingsResponse(final long serverTime, final List<MyMeetingResponse> meetings) {
+    private MyMeetingsResponse(final long serverTime, final List<MyMeetingResponse> meetings) {
         this.serverTime = serverTime;
         this.meetings = meetings;
     }
 
-    public static MyMeetingsResponse of(final LocalDateTime now,
-                                        final TimeChecker timeChecker,
-                                        final List<Meeting> meetings) {
-        final List<MyMeetingResponse> myMeetingResponses = meetings.stream()
-                .map(meeting -> MyMeetingResponse.of(now.toLocalTime(), timeChecker, meeting))
-                .collect(Collectors.toList());
-
-        return new MyMeetingsResponse(toTimestamp(now), myMeetingResponses);
+    public static MyMeetingsResponse of(final LocalDateTime now, final List<MyMeetingResponse> meetings) {
+        return new MyMeetingsResponse(toTimestamp(now), meetings);
     }
 
     private static long toTimestamp(final LocalDateTime now) {

--- a/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
@@ -115,7 +115,7 @@ public class MeetingService {
         final List<Participant> participants = participantRepository.findByUserId(userId);
 
         final List<MyMeetingResponse> myMeetingResponses = participants.stream()
-                .map(participant -> getMyMeetings(now, participant))
+                .map(participant -> generateMyMeetingResponse(now, participant))
                 .collect(Collectors.toList());
 
         return MyMeetingsResponse.of(now, myMeetingResponses);
@@ -144,7 +144,7 @@ public class MeetingService {
 
         attendance.changeAttendanceStatus(request.getAttendanceStatus());
     }
-    
+
     private Meeting findMeeting(final Long id) {
         return meetingRepository.findById(id)
                 .orElseThrow(MeetingNotFoundException::new);
@@ -196,7 +196,7 @@ public class MeetingService {
         return attendanceRepository.findByParticipantIdAndAttendanceDateNot(participant.getId(), now.toLocalDate());
     }
 
-    private MyMeetingResponse getMyMeetings(final LocalDateTime now, final Participant participant) {
+    private MyMeetingResponse generateMyMeetingResponse(final LocalDateTime now, final Participant participant) {
         final Meeting meeting = participant.getMeeting();
         return MyMeetingResponse.of(now.toLocalTime(), timeChecker, meeting,
                 getTardyCount(meeting.getEntranceTime(), now, participant));

--- a/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
@@ -2,6 +2,7 @@ package com.woowacourse.moragora.service;
 
 import com.woowacourse.moragora.dto.MeetingRequest;
 import com.woowacourse.moragora.dto.MeetingResponse;
+import com.woowacourse.moragora.dto.MyMeetingResponse;
 import com.woowacourse.moragora.dto.MyMeetingsResponse;
 import com.woowacourse.moragora.dto.UserAttendanceRequest;
 import com.woowacourse.moragora.dto.UserResponse;
@@ -112,11 +113,16 @@ public class MeetingService {
     public MyMeetingsResponse findAllByUserId(final Long userId) {
         final LocalDateTime now = currentDateTime.getValue();
         final List<Participant> participants = participantRepository.findByUserId(userId);
-        final List<Meeting> meetings = participants.stream()
-                .map(Participant::getMeeting)
-                .collect(Collectors.toList());
 
-        return MyMeetingsResponse.of(now, timeChecker, meetings);
+        final List<MyMeetingResponse> meetingResponses = new ArrayList<>();
+
+        for (final Participant participant : participants) {
+            final Meeting meeting = participant.getMeeting();
+            meetingResponses.add(MyMeetingResponse.of(now.toLocalTime(), timeChecker, meeting,
+                    getTardyCount(meeting.getEntranceTime(), now, participant)));
+        }
+
+        return MyMeetingsResponse.of(now, meetingResponses);
     }
 
     // TODO update (1 + N) -> 최적하기

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
@@ -118,7 +118,8 @@ public class MeetingAcceptanceTest extends AcceptanceTest {
                 .body("meetings.startDate", containsInAnyOrder("2022-07-10", "2022-07-13"))
                 .body("meetings.endDate", containsInAnyOrder("2022-08-10", "2022-08-13"))
                 .body("meetings.entranceTime", containsInAnyOrder("10:00", "09:00"))
-                .body("meetings.closingTime", containsInAnyOrder("10:05", "09:05"));
+                .body("meetings.closingTime", containsInAnyOrder("10:05", "09:05"))
+                .body("meetings.tardyCount", containsInAnyOrder(0, 0));
     }
 
     @DisplayName("모임의 출석을 마감하면 총 모임 횟수와 결석한 참가자들의 결일을 증가시키고 상태코드 204을 반환한다.")

--- a/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
@@ -331,14 +331,22 @@ class MeetingControllerTest extends ControllerTest {
     void findAllByUserId() throws Exception {
         // given
         final LocalDateTime now = LocalTime.of(10, 1).atDate(LocalDate.now());
-        final MyMeetingResponse myMeetingResponse = new MyMeetingResponse(1L, "모임1", true, LocalDate.of(2022, 7, 10),
-                LocalDate.of(2022, 8, 10), LocalTime.of(10, 0), LocalTime.of(10, 5));
+        final MyMeetingResponse myMeetingResponse =
+                new MyMeetingResponse(1L, "모임1", true,
+                        LocalDate.of(2022, 7, 10),
+                        LocalDate.of(2022, 8, 10),
+                        LocalTime.of(10, 0),
+                        LocalTime.of(10, 5), 1);
 
-        final MyMeetingResponse myMeetingResponse2 = new MyMeetingResponse(2L, "모임2", true, LocalDate.of(2022, 7, 15),
-                LocalDate.of(2022, 8, 15), LocalTime.of(9, 0), LocalTime.of(9, 5));
+        final MyMeetingResponse myMeetingResponse2 =
+                new MyMeetingResponse(2L, "모임2", true,
+                        LocalDate.of(2022, 7, 15),
+                        LocalDate.of(2022, 8, 15),
+                        LocalTime.of(9, 0),
+                        LocalTime.of(9, 5), 2);
 
-        final MyMeetingsResponse meetingsResponse = new MyMeetingsResponse(Timestamp.valueOf(now).getTime(),
-                List.of(myMeetingResponse, myMeetingResponse2));
+        final MyMeetingsResponse meetingsResponse =
+                MyMeetingsResponse.of(now, List.of(myMeetingResponse, myMeetingResponse2));
 
         validateToken("1");
 
@@ -358,6 +366,7 @@ class MeetingControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.meetings[*].endDate", containsInAnyOrder("2022-08-10", "2022-08-15")))
                 .andExpect(jsonPath("$.meetings[*].entranceTime", containsInAnyOrder("09:00", "10:00")))
                 .andExpect(jsonPath("$.meetings[*].closingTime", containsInAnyOrder("09:05", "10:05")))
+                .andExpect(jsonPath("$.meetings[*].tardyCount", containsInAnyOrder(1, 2)))
                 .andDo(document("meeting/find-my-meetings",
                         responseFields(
                                 fieldWithPath("serverTime").type(JsonFieldType.NUMBER)
@@ -372,7 +381,10 @@ class MeetingControllerTest extends ControllerTest {
                                 fieldWithPath("meetings[].entranceTime").type(JsonFieldType.STRING)
                                         .description("09:00"),
                                 fieldWithPath("meetings[].closingTime").type(JsonFieldType.STRING)
-                                        .description("09:05")
+                                        .description("09:05"),
+                                fieldWithPath("meetings[].tardyCount").type(JsonFieldType.NUMBER)
+                                        .description(1)
+
                         )
                 ));
     }

--- a/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.woowacourse.moragora.dto.MeetingRequest;
 import com.woowacourse.moragora.dto.MeetingResponse;
+import com.woowacourse.moragora.dto.MyMeetingResponse;
 import com.woowacourse.moragora.dto.MyMeetingsResponse;
 import com.woowacourse.moragora.dto.UserAttendanceRequest;
 import com.woowacourse.moragora.dto.UserResponse;
@@ -208,7 +209,7 @@ class MeetingServiceTest {
                 LocalTime.of(10, 0),
                 LocalTime.of(18, 0),
                 List.of(
-                        new UserResponse(1L, "aaa111@foo.com", "아스피", Status.PRESENT, 0),
+                        new UserResponse(1L, "aaa111@foo.com", "아스피", Status.PRESENT, 1),
                         new UserResponse(2L, "bbb222@foo.com", "필즈", Status.TARDY, 2),
                         new UserResponse(3L, "ccc333@foo.com", "포키", Status.PRESENT, 0),
                         new UserResponse(4L, "ddd444@foo.com", "썬", Status.PRESENT, 0),
@@ -242,7 +243,7 @@ class MeetingServiceTest {
                 LocalTime.of(10, 0),
                 LocalTime.of(18, 0),
                 List.of(
-                        new UserResponse(1L, "aaa111@foo.com", "아스피", Status.PRESENT, 0),
+                        new UserResponse(1L, "aaa111@foo.com", "아스피", Status.PRESENT, 1),
                         new UserResponse(2L, "bbb222@foo.com", "필즈", Status.TARDY, 3),
                         new UserResponse(3L, "ccc333@foo.com", "포키", Status.PRESENT, 0),
                         new UserResponse(4L, "ddd444@foo.com", "썬", Status.PRESENT, 0),
@@ -299,9 +300,13 @@ class MeetingServiceTest {
         assertThat(myMeetingsResponse).usingRecursiveComparison()
                 .ignoringFields("serverTime", "meetings.id")
                 .isEqualTo(MyMeetingsResponse.of(
-                        LocalDateTime.now(),
-                        timeChecker,
-                        List.of(meeting, meetingRequest.toEntity()))
+                        currentDateTime.getValue(),
+                        List.of(
+                                MyMeetingResponse.of(currentDateTime.getValue().toLocalTime(), timeChecker,
+                                        meeting, 1),
+                                MyMeetingResponse.of(currentDateTime.getValue().toLocalTime(), timeChecker,
+                                        meetingRequest.toEntity(), 0)
+                        ))
                 );
     }
 


### PR DESCRIPTION
Close #172 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/mymeetingresponse-refactor -> dev

## 요구사항
- User가 속한 각 미팅 정보를 넘겨줄 때, User 개인의 지각 스택을 함께 보내준다

## 변경사항
- MMeetingResponse에 tardyCount 추가

## [Optional] 논의하고 싶은 내용

<!--Close #issue_number를 작성한다.-->

