### PR TITLE
[BE] 출결 체크 시 status mapping 및 마감 시간 오류 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/moragora/entity/Status.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/Status.java
@@ -9,7 +9,7 @@ public enum Status {
     @JsonCreator
     public static Status fromEnum(String value) {
         for (Status status : Status.values()) {
-            if (status.name().equals(value)) {
+            if (status.name().equalsIgnoreCase(value)) {
                 return status;
             }
         }

--- a/backend/src/main/java/com/woowacourse/moragora/service/closingstrategy/RealTimeChecker.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/closingstrategy/RealTimeChecker.java
@@ -15,7 +15,7 @@ public class RealTimeChecker extends TimeChecker {
     @Override
     public boolean isAttendanceTime(final LocalTime now, final LocalTime entranceTime) {
         final LocalTime attendanceStartTime = entranceTime.minusMinutes(ATTENDANCE_START_INTERVAL);
-        final LocalTime attendanceClosingTime = now.plusMinutes(ATTENDANCE_END_INTERVAL);
+        final LocalTime attendanceClosingTime = entranceTime.plusMinutes(ATTENDANCE_END_INTERVAL);
 
         return (now.isAfter(attendanceStartTime) && now.isBefore(attendanceClosingTime)) ||
                 now.equals(attendanceStartTime);


### PR DESCRIPTION
Close #192

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/attendance-bug-fix -> dev

## 요구사항
- 출결 체크 요청 시 status 정확하게 mapping
- 출결 마감 시간 연산 오류 수정

## 변경사항
- Status enum 동등성 비교 시 case ignore
- 출결 마감 시간 기준을 서버시간 -> 모임 시작 시간으로 수정

<!--Close #issue_number를 작성한다.-->

