### PR TITLE
[FE] 멤버 검색에 현재 유저 포함되는 버그 해결

### DIFF
--- a/frontend/src/components/MemberAddInput/index.tsx
+++ b/frontend/src/components/MemberAddInput/index.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import * as S from './MemberAddInput.styled';
 import useQuerySelectItems from 'hooks/useQuerySelectItems';
 import Input from 'components/@shared/Input';
 import { UserQueryWithKeywordResponse } from 'types/userType';
+import { userContext } from 'contexts/userContext';
 
 const MemberAddInput: React.FC<
   Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> &
@@ -20,6 +21,11 @@ const MemberAddInput: React.FC<
   ...props
 }) => {
   const [isDropdownOpened, setIsDropdownOpened] = useState(false);
+  const currentUserState = useContext(userContext);
+
+  const filteredQueryResult = queryResult.filter(
+    ({ id }) => id !== currentUserState?.user?.id
+  );
 
   const openDropdown = () => {
     setIsDropdownOpened(true);
@@ -62,9 +68,9 @@ const MemberAddInput: React.FC<
         }}
         {...props}
       />
-      {isDropdownOpened && queryResult.length > 0 && (
+      {isDropdownOpened && filteredQueryResult.length > 0 && (
         <S.QueryResultList>
-          {queryResult.map((user) => (
+          {filteredQueryResult.map((user) => (
             <S.QueryResultListItem
               key={user.id}
               onMouseDown={(e) => {


### PR DESCRIPTION
Close #197 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/fe/member-include-user-bug -> dev

## 요구사항
- 미팅 추가 페이지에서 멤버를 추가할 때 생성 유저가 포함되지 않음

## 변경사항
- 검색된 멤버들인 `queryResult`에서 현재 유저를 필터링한다.

<!--Close #issue_number를 작성한다.-->

