### PR TITLE
[BE] 로그인 회원의 참가 미팅 목록 응답시 출결 시작, 모임 마감 시간 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/moragora/dto/MyMeetingResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/MyMeetingResponse.java
@@ -18,6 +18,8 @@ public class MyMeetingResponse {
     private final LocalDate startDate;
     private final LocalDate endDate;
     private final String entranceTime;
+    private final String leaveTime;
+    private final String openingTime;
     private final String closingTime;
     private final int tardyCount;
 
@@ -27,6 +29,8 @@ public class MyMeetingResponse {
                              final LocalDate startDate,
                              final LocalDate endDate,
                              final LocalTime entranceTime,
+                             final LocalTime leaveTime,
+                             final LocalTime openingTime,
                              final LocalTime closingTime,
                              final int tardyCount) {
         this.id = id;
@@ -35,6 +39,8 @@ public class MyMeetingResponse {
         this.startDate = startDate;
         this.endDate = endDate;
         this.entranceTime = entranceTime.format(TIME_FORMATTER);
+        this.leaveTime = leaveTime.format(TIME_FORMATTER);
+        this.openingTime = openingTime.format(TIME_FORMATTER);
         this.closingTime = closingTime.format(TIME_FORMATTER);
         this.tardyCount = tardyCount;
     }
@@ -51,6 +57,8 @@ public class MyMeetingResponse {
                 meeting.getStartDate(),
                 meeting.getEndDate(),
                 meeting.getEntranceTime(),
+                meeting.getLeaveTime(),
+                timeChecker.calculateOpeningTime(meeting.getEntranceTime()),
                 timeChecker.calculateClosingTime(meeting.getEntranceTime()),
                 tardyCount
         );

--- a/backend/src/main/java/com/woowacourse/moragora/service/closingstrategy/RealTimeChecker.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/closingstrategy/RealTimeChecker.java
@@ -35,6 +35,11 @@ public class RealTimeChecker extends TimeChecker {
     }
 
     @Override
+    public LocalTime calculateOpeningTime(final LocalTime entranceTime) {
+        return entranceTime.minusMinutes(ATTENDANCE_START_INTERVAL);
+    }
+
+    @Override
     public LocalTime calculateClosingTime(final LocalTime entranceTime) {
         return entranceTime.plusMinutes(ATTENDANCE_END_INTERVAL);
     }

--- a/backend/src/main/java/com/woowacourse/moragora/service/closingstrategy/TimeChecker.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/closingstrategy/TimeChecker.java
@@ -17,5 +17,7 @@ public abstract class TimeChecker {
 
     public abstract boolean isExcessClosingTime(final LocalTime now, final LocalTime entranceTime);
 
+    public abstract LocalTime calculateOpeningTime(final LocalTime entranceTime);
+
     public abstract LocalTime calculateClosingTime(final LocalTime entranceTime);
 }

--- a/backend/src/test/java/com/woowacourse/moragora/FakeTimeChecker.java
+++ b/backend/src/test/java/com/woowacourse/moragora/FakeTimeChecker.java
@@ -34,6 +34,11 @@ public class FakeTimeChecker extends TimeChecker {
     }
 
     @Override
+    public LocalTime calculateOpeningTime(final LocalTime entranceTime) {
+        return entranceTime.minusMinutes(30);
+    }
+
+    @Override
     public LocalTime calculateClosingTime(final LocalTime entranceTime) {
         return entranceTime.plusMinutes(5);
     }

--- a/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
@@ -336,6 +336,8 @@ class MeetingControllerTest extends ControllerTest {
                         LocalDate.of(2022, 7, 10),
                         LocalDate.of(2022, 8, 10),
                         LocalTime.of(10, 0),
+                        LocalTime.of(11, 0),
+                        LocalTime.of(9, 30),
                         LocalTime.of(10, 5), 1);
 
         final MyMeetingResponse myMeetingResponse2 =
@@ -343,6 +345,8 @@ class MeetingControllerTest extends ControllerTest {
                         LocalDate.of(2022, 7, 15),
                         LocalDate.of(2022, 8, 15),
                         LocalTime.of(9, 0),
+                        LocalTime.of(10, 0),
+                        LocalTime.of(8, 30),
                         LocalTime.of(9, 5), 2);
 
         final MyMeetingsResponse meetingsResponse =
@@ -365,6 +369,8 @@ class MeetingControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.meetings[*].startDate", containsInAnyOrder("2022-07-10", "2022-07-15")))
                 .andExpect(jsonPath("$.meetings[*].endDate", containsInAnyOrder("2022-08-10", "2022-08-15")))
                 .andExpect(jsonPath("$.meetings[*].entranceTime", containsInAnyOrder("09:00", "10:00")))
+                .andExpect(jsonPath("$.meetings[*].leaveTime", containsInAnyOrder("10:00", "11:00")))
+                .andExpect(jsonPath("$.meetings[*].openingTime", containsInAnyOrder("08:30", "09:30")))
                 .andExpect(jsonPath("$.meetings[*].closingTime", containsInAnyOrder("09:05", "10:05")))
                 .andExpect(jsonPath("$.meetings[*].tardyCount", containsInAnyOrder(1, 2)))
                 .andDo(document("meeting/find-my-meetings",
@@ -380,6 +386,10 @@ class MeetingControllerTest extends ControllerTest {
                                         .description("2022-08-10"),
                                 fieldWithPath("meetings[].entranceTime").type(JsonFieldType.STRING)
                                         .description("09:00"),
+                                fieldWithPath("meetings[].leaveTime").type(JsonFieldType.STRING)
+                                        .description("10:00"),
+                                fieldWithPath("meetings[].openingTime").type(JsonFieldType.STRING)
+                                        .description("08:30"),
                                 fieldWithPath("meetings[].closingTime").type(JsonFieldType.STRING)
                                         .description("09:05"),
                                 fieldWithPath("meetings[].tardyCount").type(JsonFieldType.NUMBER)

--- a/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
@@ -290,6 +290,8 @@ class MeetingServiceTest {
                 .willReturn(LocalDateTime.of(2022, 7, 14, 10, 5));
         given(timeChecker.calculateClosingTime(entranceTime))
                 .willReturn(entranceTime.plusMinutes(5));
+        given(timeChecker.calculateOpeningTime(entranceTime))
+                .willReturn(entranceTime.minusMinutes(30));
 
         meetingService.save(meetingRequest, userId);
 


### PR DESCRIPTION
Close #196 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/meeting-find-my-add-fields -> dev

## 요구사항
- 로그인 회원의 참가 미팅 목록을 조회하면 출결 시작 시간과 모임 마감 시간 함께 응답

## 변경사항

<!--Close #issue_number를 작성한다.-->

