### PR TITLE
[BE] 패스워드 검증에 대한 책임 분리

### DIFF
--- a/backend/src/main/java/com/woowacourse/auth/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import com.woowacourse.auth.dto.LoginRequest;
 import com.woowacourse.auth.dto.LoginResponse;
 import com.woowacourse.auth.exception.LoginFailException;
 import com.woowacourse.auth.support.JwtTokenProvider;
+import com.woowacourse.moragora.entity.user.RawPassword;
 import com.woowacourse.moragora.entity.user.User;
 import com.woowacourse.moragora.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -25,7 +26,8 @@ public class AuthService {
         final User user = userRepository.findByEmail(loginRequest.getEmail())
                 .orElseThrow(() -> new LoginFailException());
 
-        user.checkPassword(loginRequest.getPassword());
+        final RawPassword rawPassword = new RawPassword(loginRequest.getPassword());
+        user.checkPassword(rawPassword);
         final String accessToken = jwtTokenProvider.createToken(String.valueOf(user.getId()));
         return new LoginResponse(accessToken);
     }

--- a/backend/src/main/java/com/woowacourse/moragora/entity/user/EncodedPassword.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/user/EncodedPassword.java
@@ -23,8 +23,7 @@ public class EncodedPassword {
         return new EncodedPassword(rawPassword.encode());
     }
 
-    public boolean isSamePassword(final String plainPassword) {
-        final String encryptedPassword = CryptoEncoder.encrypt(plainPassword);
-        return encryptedPassword.equals(value);
+    public boolean isSamePassword(final RawPassword rawPassword) {
+        return value.equals(rawPassword.encode());
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/entity/user/User.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/user/User.java
@@ -61,8 +61,8 @@ public class User {
         }
     }
 
-    public void checkPassword(final String plainPassword) {
-        if (!password.isSamePassword(plainPassword)) {
+    public void checkPassword(final RawPassword rawPassword) {
+        if (!password.isSamePassword(rawPassword)) {
             throw new LoginFailException();
         }
     }

--- a/backend/src/test/java/com/woowacourse/moragora/entity/user/UserTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/entity/user/UserTest.java
@@ -55,7 +55,7 @@ class UserTest {
         final User user = new User("asdf@naver.com", EncodedPassword.fromRawValue(plainPassword), "kun");
 
         // when, then
-        assertThatCode(() -> user.checkPassword(plainPassword))
+        assertThatCode(() -> user.checkPassword(new RawPassword(plainPassword)))
                 .doesNotThrowAnyException();
     }
 
@@ -68,7 +68,7 @@ class UserTest {
         final String wrongPassword = "wrongPassword123!";
 
         // when, then
-        assertThatThrownBy(() -> user.checkPassword(wrongPassword))
+        assertThatThrownBy(() -> user.checkPassword(new RawPassword(wrongPassword)))
                 .isInstanceOf(LoginFailException.class);
     }
 }


### PR DESCRIPTION
Close #208 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/login -> dev

## 요구사항
- 패스워드 검증 책임 분리

## 변경사항
- 기존 `EncodedPassword`에서 사용하던 `CryptoEncoder`를 제거하고 `RawPassword`를 받도록 수정

