### PR TITLE
[FE] useQuery, useMutation 구현

### DIFF
--- a/frontend/src/consts/index.ts
+++ b/frontend/src/consts/index.ts
@@ -1,1 +1,12 @@
 export const TOKEN_ERROR_STATUS_CODES = [401, 404];
+export const QUERY_STATUS = {
+  LOADING: 'loading',
+  ERROR: 'error',
+  SUCCESS: 'success',
+};
+export const MUTATION_STATUS = {
+  IDLE: 'idle',
+  LOADING: 'loading',
+  ERROR: 'error',
+  SUCCESS: 'success',
+};

--- a/frontend/src/contexts/queryClient.tsx
+++ b/frontend/src/contexts/queryClient.tsx
@@ -1,0 +1,20 @@
+import { useContext, createContext } from 'react';
+
+type QueryClient = {
+  cache: Record<string, any>;
+  invalidateQueries: (key: string) => void;
+  isCached: (key: string) => boolean;
+};
+
+export const queryClient: QueryClient = {
+  cache: {},
+  invalidateQueries: function (key) {
+    delete this.cache[key];
+  },
+  isCached: (key) =>
+    Object.prototype.hasOwnProperty.call(queryClient.cache, key),
+};
+
+const QueryClientContext = createContext(queryClient);
+export const useQueryClient = () => useContext(QueryClientContext);
+export const QueryClientProvider = QueryClientContext.Provider;

--- a/frontend/src/hooks/useMutation.ts
+++ b/frontend/src/hooks/useMutation.ts
@@ -1,0 +1,76 @@
+import { useState, useRef } from 'react';
+import { MUTATION_STATUS } from 'consts';
+
+type DefaultData = any;
+type Variables = Record<string, any> | null;
+type MutationOptions<TData> = {
+  onSuccess: (data: TData, variables: Variables) => Promise<void> | void;
+  onError: (error: Error, variables: Variables) => Promise<void> | void;
+  onSettled: (
+    data: TData | undefined,
+    error: Error | undefined,
+    variables: Variables
+  ) => Promise<void> | void;
+  onMutate: (variables: Variables) => Promise<void> | void;
+  retry: number;
+};
+
+const useMutation = <
+  TData extends DefaultData = DefaultData,
+  TVariables extends Variables = Variables
+>(
+  mutationFn: (variables: TVariables) => Promise<TData>,
+  {
+    onSuccess,
+    onSettled,
+    onError,
+    onMutate,
+    retry = 0,
+  }: Partial<MutationOptions<TData>> = {}
+) => {
+  const [data, setData] = useState<TData>();
+  const [error, setError] = useState<Error>();
+  const [status, setStatus] = useState(MUTATION_STATUS.IDLE);
+  const retryCountRef = useRef<number>(0);
+  const isIdle = status === MUTATION_STATUS.IDLE;
+  const isLoading = status === MUTATION_STATUS.LOADING;
+  const isError = status === MUTATION_STATUS.ERROR;
+  const isSuccess = status === MUTATION_STATUS.SUCCESS;
+
+  const mutate = async (variables: TVariables) => {
+    if (isLoading) {
+      return;
+    }
+
+    try {
+      setStatus(MUTATION_STATUS.LOADING);
+      await onMutate?.(variables);
+
+      const data = await mutationFn(variables);
+
+      setData(data);
+      setStatus(MUTATION_STATUS.SUCCESS);
+      await onSuccess?.(data, variables);
+    } catch (error) {
+      setStatus(MUTATION_STATUS.ERROR);
+
+      if (!(error instanceof Error)) {
+        return;
+      }
+
+      setError(error);
+      await onError?.(error, variables);
+
+      if (retryCountRef.current < retry) {
+        retryCountRef.current += 1;
+        await mutate(variables);
+      }
+    } finally {
+      await onSettled?.(data, error, variables);
+    }
+  };
+
+  return { data, error, status, isIdle, isLoading, isError, isSuccess, mutate };
+};
+
+export default useMutation;

--- a/frontend/src/hooks/useMutation.ts
+++ b/frontend/src/hooks/useMutation.ts
@@ -1,11 +1,8 @@
 import { useState, useRef } from 'react';
 import { MUTATION_STATUS } from 'consts';
-import { DefaultData, Variables, MutationOptions } from 'types/useQueryType';
+import { Variables, MutationOptions } from 'types/queryType';
 
-const useMutation = <
-  TData extends DefaultData = DefaultData,
-  TVariables extends Variables = Variables
->(
+const useMutation = <TData = any, TVariables extends Variables = Variables>(
   mutationFn: (variables: TVariables) => Promise<TData>,
   {
     onSuccess,

--- a/frontend/src/hooks/useMutation.ts
+++ b/frontend/src/hooks/useMutation.ts
@@ -1,19 +1,6 @@
 import { useState, useRef } from 'react';
 import { MUTATION_STATUS } from 'consts';
-
-type DefaultData = any;
-type Variables = Record<string, any> | null;
-type MutationOptions<TData> = {
-  onSuccess: (data: TData, variables: Variables) => Promise<void> | void;
-  onError: (error: Error, variables: Variables) => Promise<void> | void;
-  onSettled: (
-    data: TData | undefined,
-    error: Error | undefined,
-    variables: Variables
-  ) => Promise<void> | void;
-  onMutate: (variables: Variables) => Promise<void> | void;
-  retry: number;
-};
+import { DefaultData, Variables, MutationOptions } from 'types/useQueryType';
 
 const useMutation = <
   TData extends DefaultData = DefaultData,
@@ -26,7 +13,7 @@ const useMutation = <
     onError,
     onMutate,
     retry = 0,
-  }: Partial<MutationOptions<TData>> = {}
+  }: Partial<MutationOptions<TData, TVariables>> = {}
 ) => {
   const [data, setData] = useState<TData>();
   const [error, setError] = useState<Error>();

--- a/frontend/src/hooks/useQuery.ts
+++ b/frontend/src/hooks/useQuery.ts
@@ -1,22 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { useQueryClient } from 'contexts/queryClient';
 import { QUERY_STATUS } from 'consts';
-
-type DefaultData = any;
-type QueryOptions<TData> = {
-  onSuccess: (data: TData) => Promise<void> | void;
-  onError: (error: Error) => Promise<void> | void;
-  onSettled: (
-    data: TData | undefined,
-    error: Error | undefined
-  ) => Promise<void> | void;
-  enabled: boolean;
-  refetchOnMount: boolean;
-  refetchOnWindowFocus: boolean;
-  refetchInterval: number;
-  retry: number;
-  cacheTime: number;
-};
+import { DefaultData, QueryOptions } from 'types/useQueryType';
 
 const useQuery = <TData extends DefaultData = DefaultData>(
   key: string[],

--- a/frontend/src/hooks/useQuery.ts
+++ b/frontend/src/hooks/useQuery.ts
@@ -1,0 +1,132 @@
+import { useEffect, useState, useRef, useCallback } from 'react';
+import { useQueryClient } from 'contexts/queryClient';
+import { QUERY_STATUS } from 'consts';
+
+type DefaultData = any;
+type QueryOptions<TData> = {
+  onSuccess: (data: TData) => Promise<void> | void;
+  onError: (error: Error) => Promise<void> | void;
+  onSettled: (
+    data: TData | undefined,
+    error: Error | undefined
+  ) => Promise<void> | void;
+  enabled: boolean;
+  refetchOnMount: boolean;
+  refetchOnWindowFocus: boolean;
+  refetchInterval: number;
+  retry: number;
+  cacheTime: number;
+};
+
+const useQuery = <TData extends DefaultData = DefaultData>(
+  key: string[],
+  queryFn: () => Promise<TData>,
+  {
+    onSuccess,
+    onError,
+    onSettled,
+    enabled = true,
+    refetchOnMount = true,
+    refetchOnWindowFocus,
+    refetchInterval,
+    retry = 0,
+    cacheTime = 0,
+  }: Partial<QueryOptions<TData>> = {}
+) => {
+  const queryClient = useQueryClient();
+  const [data, setData] = useState<TData>();
+  const [error, setError] = useState<Error>();
+  const [status, setStatus] = useState(QUERY_STATUS.LOADING);
+  const retryCountRef = useRef<number>(0);
+  const intervalId = useRef<NodeJS.Timer>();
+  const staleTimerId = useRef<NodeJS.Timer>();
+  const joinedKey = key.join('.');
+  const isLoading = status === QUERY_STATUS.LOADING;
+  const isError = status === QUERY_STATUS.ERROR;
+  const isSuccess = status === QUERY_STATUS.SUCCESS;
+
+  const cacheData = (data: TData) => {
+    queryClient.cache[joinedKey] = data;
+    staleTimerId.current = setTimeout(() => {
+      queryClient.invalidateQueries(joinedKey);
+    }, cacheTime);
+  };
+
+  const queryData = async (): Promise<TData> => {
+    let data;
+
+    if (queryClient.isCached(joinedKey)) {
+      data = queryClient.cache[joinedKey];
+    } else {
+      data = await queryFn();
+
+      cacheData(data);
+    }
+
+    return data;
+  };
+
+  const refetch = async () => {
+    try {
+      setStatus(QUERY_STATUS.LOADING);
+
+      const data = await queryData();
+
+      setData(data);
+      setStatus(QUERY_STATUS.SUCCESS);
+      await onSuccess?.(data);
+    } catch (error) {
+      setStatus(QUERY_STATUS.ERROR);
+
+      if (!(error instanceof Error)) {
+        return;
+      }
+
+      setError(error);
+      await onError?.(error);
+
+      const shouldRetry = retryCountRef.current < retry;
+
+      if (shouldRetry) {
+        retryCountRef.current += 1;
+        await refetch();
+      }
+    } finally {
+      await onSettled?.(data, error);
+    }
+  };
+
+  const handleFocus = useCallback(() => {
+    if (refetchOnWindowFocus) {
+      refetch();
+    }
+  }, [refetchOnWindowFocus]);
+
+  useEffect(() => {
+    window.addEventListener('focus', handleFocus);
+
+    if (refetchInterval) {
+      intervalId.current = setInterval(() => {
+        refetch();
+      }, refetchInterval);
+    }
+
+    return () => {
+      window.removeEventListener('focus', handleFocus);
+
+      if (intervalId.current) {
+        clearInterval(intervalId.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (enabled && refetchOnMount) {
+      refetch();
+    }
+  }, [enabled]);
+
+  return { data, error, status, isLoading, isError, isSuccess };
+};
+
+export default useQuery;

--- a/frontend/src/hooks/useQuery.ts
+++ b/frontend/src/hooks/useQuery.ts
@@ -1,9 +1,9 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { useQueryClient } from 'contexts/queryClient';
 import { QUERY_STATUS } from 'consts';
-import { DefaultData, QueryOptions } from 'types/useQueryType';
+import { QueryOptions } from 'types/queryType';
 
-const useQuery = <TData extends DefaultData = DefaultData>(
+const useQuery = <TData = any>(
   key: string[],
   queryFn: () => Promise<TData>,
   {

--- a/frontend/src/types/queryType.ts
+++ b/frontend/src/types/queryType.ts
@@ -1,5 +1,3 @@
-export type DefaultData = any;
-
 export type Variables = Record<string, any> | null;
 
 export type QueryOptions<TData> = {

--- a/frontend/src/types/useQueryType.ts
+++ b/frontend/src/types/useQueryType.ts
@@ -1,0 +1,30 @@
+export type DefaultData = any;
+
+export type Variables = Record<string, any> | null;
+
+export type QueryOptions<TData> = {
+  onSuccess: (data: TData) => Promise<void> | void;
+  onError: (error: Error) => Promise<void> | void;
+  onSettled: (
+    data: TData | undefined,
+    error: Error | undefined
+  ) => Promise<void> | void;
+  enabled: boolean;
+  refetchOnMount: boolean;
+  refetchOnWindowFocus: boolean;
+  refetchInterval: number;
+  retry: number;
+  cacheTime: number;
+};
+
+export type MutationOptions<TData, TVariables> = {
+  onSuccess: (data: TData, variables: TVariables) => Promise<void> | void;
+  onError: (error: Error, variables: TVariables) => Promise<void> | void;
+  onSettled: (
+    data: TData | undefined,
+    error: Error | undefined,
+    variables: TVariables
+  ) => Promise<void> | void;
+  onMutate: (variables: TVariables) => Promise<void> | void;
+  retry: number;
+};


### PR DESCRIPTION
Close #223

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/fe/async-fetch-hook -> dev

## 요구사항
- [x] useQuery, useMutation을 구현한다.

## 변경사항
- 커스텀 훅 구현
- 컨텍스트 API 사용하여 캐시 데이터 컨텍스트 추가
- `const` 폴더에 `QUERY_STATUS`, `MUTATION_STATUS` 상수  추가

## [Optional] 논의하고 싶은 내용

현재 타입을 분리한 파일인 `useQueryType.ts`의 네이밍이 `useMutation`을 포함하지 않는 것처럼 보여 이에 대한 논의가 필요합니다.