### PR TITLE
[BE] 현재 서버 시간 요청 api 분리

### DIFF
--- a/backend/src/docs/asciidoc/common.asciidoc
+++ b/backend/src/docs/asciidoc/common.asciidoc
@@ -1,0 +1,25 @@
+= Auth
+:toc: left
+:toclevels: 2
+:sectlinks:
+:source-highlighter: highlightjs
+
+[[home]]
+== home
+
+* link:index.html[홈으로 가기]
+
+[[server-time]]
+== 현재 서버 시간
+
+=== HTTP request
+
+include::{snippets}/common/server-time/http-request.adoc[]
+
+=== HTTP response
+
+include::{snippets}/common/server-time/http-response.adoc[]
+
+=== Response fields
+
+include::{snippets}/common/server-time/response-fields.adoc[]

--- a/backend/src/docs/asciidoc/index.asciidoc
+++ b/backend/src/docs/asciidoc/index.asciidoc
@@ -9,6 +9,7 @@
 * link:auth.html[Auth]
 * link:user.html[User]
 * link:meeting.html[Meeting]
+* link:common.html[Common]
 
 [[overview]]
 == Overview

--- a/backend/src/main/java/com/woowacourse/moragora/controller/CommonController.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/CommonController.java
@@ -1,0 +1,23 @@
+package com.woowacourse.moragora.controller;
+
+import com.woowacourse.moragora.dto.ServerTimeResponse;
+import com.woowacourse.moragora.service.CommonService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CommonController {
+
+    private final CommonService commonService;
+
+    public CommonController(final CommonService commonService) {
+        this.commonService = commonService;
+    }
+
+    @GetMapping("/server-time")
+    public ResponseEntity<ServerTimeResponse> showServerTime() {
+        final ServerTimeResponse response = commonService.getServerTime();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/moragora/dto/MyMeetingsResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/MyMeetingsResponse.java
@@ -1,26 +1,14 @@
 package com.woowacourse.moragora.dto;
 
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Getter;
 
 @Getter
 public class MyMeetingsResponse {
 
-    private final long serverTime;
     private final List<MyMeetingResponse> meetings;
 
-    private MyMeetingsResponse(final long serverTime, final List<MyMeetingResponse> meetings) {
-        this.serverTime = serverTime;
+    public MyMeetingsResponse(final List<MyMeetingResponse> meetings) {
         this.meetings = meetings;
-    }
-
-    public static MyMeetingsResponse of(final LocalDateTime now, final List<MyMeetingResponse> meetings) {
-        return new MyMeetingsResponse(toTimestamp(now), meetings);
-    }
-
-    private static long toTimestamp(final LocalDateTime now) {
-        return Timestamp.valueOf(now).getTime();
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/ServerTimeResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/ServerTimeResponse.java
@@ -1,0 +1,23 @@
+package com.woowacourse.moragora.dto;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class ServerTimeResponse {
+
+    private final long serverTime;
+
+    private ServerTimeResponse(final long serverTime) {
+        this.serverTime = serverTime;
+    }
+
+    public ServerTimeResponse(final LocalDateTime serverTime) {
+        this(toTimestamp(serverTime));
+    }
+
+    private static long toTimestamp(final LocalDateTime serverTime) {
+        return Timestamp.valueOf(serverTime).getTime();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/moragora/service/CommonService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/CommonService.java
@@ -1,0 +1,21 @@
+package com.woowacourse.moragora.service;
+
+import com.woowacourse.moragora.dto.ServerTimeResponse;
+import com.woowacourse.moragora.support.ServerTimeManager;
+import java.time.LocalDateTime;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CommonService {
+
+    private final ServerTimeManager serverTimeManager;
+
+    public CommonService(final ServerTimeManager serverTimeManager) {
+        this.serverTimeManager = serverTimeManager;
+    }
+
+    public ServerTimeResponse getServerTime() {
+        final LocalDateTime now = serverTimeManager.getDateAndTime();
+        return new ServerTimeResponse(now);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
@@ -103,7 +103,7 @@ public class MeetingService {
                 .map(participant -> generateMyMeetingResponse(participant, meetingAttendances))
                 .collect(Collectors.toList());
 
-        return MyMeetingsResponse.of(serverTimeManager.getDateAndTime(), myMeetingResponses);
+        return new MyMeetingsResponse(myMeetingResponses);
     }
 
     /**

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/CommonAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/CommonAcceptanceTest.java
@@ -1,0 +1,38 @@
+package com.woowacourse.moragora.acceptance;
+
+import static org.mockito.BDDMockito.given;
+
+import com.woowacourse.moragora.support.ServerTimeManager;
+import io.restassured.response.ValidatableResponse;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+
+public class CommonAcceptanceTest extends AcceptanceTest {
+
+    @MockBean
+    private ServerTimeManager serverTimeManager;
+
+    @DisplayName("서버 시간을 조회하면 서버의 현재 시간과 상태코드 200을 반환한다.")
+    @Test
+    void showServerTime() {
+        // given
+        final LocalDateTime now = LocalDateTime.now();
+        final Timestamp expected = Timestamp.valueOf(now);
+
+        given(serverTimeManager.getDateAndTime())
+                .willReturn(now);
+
+        // when
+        final ValidatableResponse response = get("/server-time");
+
+        // then
+        response.statusCode(HttpStatus.OK.value())
+                .body("serverTime", Matchers.equalTo(expected.getTime()));
+    }
+
+}

--- a/backend/src/test/java/com/woowacourse/moragora/controller/CommonControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/CommonControllerTest.java
@@ -1,0 +1,42 @@
+package com.woowacourse.moragora.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.woowacourse.moragora.dto.ServerTimeResponse;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class CommonControllerTest extends ControllerTest {
+
+    @DisplayName("서버의 현재 시간을 조회한다.")
+    @Test
+    void showServerTime() throws Exception {
+        // given
+        final LocalDateTime now = LocalDateTime.now();
+        final Timestamp expected = Timestamp.valueOf(now);
+
+        given(commonService.getServerTime())
+                .willReturn(new ServerTimeResponse(now));
+
+        // when
+        final ResultActions resultActions = performGet("/server-time");
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("serverTime").value(expected.getTime()))
+                .andDo(document("common/server-time",
+                        responseFields(
+                                fieldWithPath("serverTime").type(JsonFieldType.NUMBER).description(expected.getTime())
+                        )
+                ));
+    }
+}

--- a/backend/src/test/java/com/woowacourse/moragora/controller/ControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/ControllerTest.java
@@ -10,6 +10,7 @@ import com.woowacourse.auth.controller.AuthController;
 import com.woowacourse.auth.service.AuthService;
 import com.woowacourse.auth.support.JwtTokenProvider;
 import com.woowacourse.moragora.service.AttendanceService;
+import com.woowacourse.moragora.service.CommonService;
 import com.woowacourse.moragora.service.MeetingService;
 import com.woowacourse.moragora.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,7 +26,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
         MeetingController.class,
         AttendanceController.class,
         UserController.class,
-        AuthController.class})
+        AuthController.class,
+        CommonController.class})
 @AutoConfigureRestDocs
 public class ControllerTest {
 
@@ -40,6 +42,9 @@ public class ControllerTest {
 
     @MockBean
     protected UserService userService;
+
+    @MockBean
+    protected CommonService commonService;
 
     @MockBean
     protected JwtTokenProvider jwtTokenProvider;

--- a/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
@@ -2,7 +2,6 @@ package com.woowacourse.moragora.controller;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -23,9 +22,7 @@ import com.woowacourse.moragora.entity.Status;
 import com.woowacourse.moragora.exception.meeting.IllegalStartEndDateException;
 import com.woowacourse.moragora.exception.participant.InvalidParticipantException;
 import com.woowacourse.moragora.exception.user.UserNotFoundException;
-import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -325,7 +322,6 @@ class MeetingControllerTest extends ControllerTest {
     @Test
     void findAllByUserId() throws Exception {
         // given
-        final LocalDateTime now = LocalTime.of(10, 1).atDate(LocalDate.now());
         final MyMeetingResponse myMeetingResponse =
                 new MyMeetingResponse(1L, "모임1", true,
                         LocalDate.of(2022, 7, 10),
@@ -341,7 +337,7 @@ class MeetingControllerTest extends ControllerTest {
                         LocalTime.of(9, 5), 2);
 
         final MyMeetingsResponse meetingsResponse =
-                MyMeetingsResponse.of(now, List.of(myMeetingResponse, myMeetingResponse2));
+                new MyMeetingsResponse(List.of(myMeetingResponse, myMeetingResponse2));
 
         validateToken("1");
 
@@ -352,9 +348,7 @@ class MeetingControllerTest extends ControllerTest {
         // then
         performGet("/meetings/me")
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.serverTime", is(Timestamp.valueOf(now).getTime())))
                 .andExpect(jsonPath("$.meetings[*].id", containsInAnyOrder(1, 2)))
-                .andExpect(jsonPath("$.serverTime", is(Timestamp.valueOf(now).getTime())))
                 .andExpect(jsonPath("$.meetings[*].name", containsInAnyOrder("모임1", "모임2")))
                 .andExpect(jsonPath("$.meetings[*].isActive", containsInAnyOrder(true, true)))
                 .andExpect(jsonPath("$.meetings[*].startDate", containsInAnyOrder("2022-07-10", "2022-07-15")))
@@ -364,8 +358,6 @@ class MeetingControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.meetings[*].tardyCount", containsInAnyOrder(1, 2)))
                 .andDo(document("meeting/find-my-meetings",
                         responseFields(
-                                fieldWithPath("serverTime").type(JsonFieldType.NUMBER)
-                                        .description(Timestamp.valueOf(now).getTime()),
                                 fieldWithPath("meetings[].id").type(JsonFieldType.NUMBER).description(1L),
                                 fieldWithPath("meetings[].name").type(JsonFieldType.STRING).description("모임1"),
                                 fieldWithPath("meetings[].isActive").type(JsonFieldType.BOOLEAN).description(true),

--- a/backend/src/test/java/com/woowacourse/moragora/service/CommonServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/CommonServiceTest.java
@@ -1,0 +1,27 @@
+package com.woowacourse.moragora.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.moragora.dto.ServerTimeResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CommonServiceTest {
+
+    @Autowired
+    private CommonService commonService;
+
+    @DisplayName("현재 서버 시간을 timestamp 형식으로 조회한다")
+    @Test
+    void getServerTime() {
+        // given, when
+        final ServerTimeResponse response = commonService.getServerTime();
+
+        // then
+        assertThat(response.getServerTime()).isNotNull();
+    }
+
+}

--- a/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
@@ -280,9 +280,8 @@ class MeetingServiceTest {
 
         // then
         assertThat(myMeetingsResponse).usingRecursiveComparison()
-                .ignoringFields("serverTime", "meetings.id")
-                .isEqualTo(MyMeetingsResponse.of(
-                        serverTimeManager.getDateAndTime(),
+                .ignoringFields("meetings.id")
+                .isEqualTo(new MyMeetingsResponse(
                         List.of(
                                 MyMeetingResponse.of(meeting, false,
                                         serverTimeManager.calculateClosingTime(entranceTime), 1),


### PR DESCRIPTION
Close #232 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/show-server-time -> dev

## 요구사항
<!--로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
- 자신의 미팅 목록 조회에 포함되어 있던 서버 시간 응답을 별도 api로 분리

## 변경사항

## [Optional] 논의하고 싶은 내용
- `CommonService.getServerTime()`의 로직이 너무 단순하고 서버 환경 의존적이어서 test 로직 짜기가 애매하네요... 일단은 test를 위한 test로 만들었습니다 😢 
