### PR TITLE
[BE] 커피스택 비우기 기능 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/ApplicationStartupRunner.java
+++ b/backend/src/main/java/com/woowacourse/ApplicationStartupRunner.java
@@ -77,29 +77,29 @@ public class ApplicationStartupRunner implements ApplicationListener<ContextRefr
         participantRepository.save(participant6);
         participantRepository.save(participant7);
 
-        final Attendance attendance1 = new Attendance(participant1, LocalDate.of(2022, 7, 12), Status.TARDY);
-        final Attendance attendance2 = new Attendance(participant2, LocalDate.of(2022, 7, 12), Status.TARDY);
-        final Attendance attendance3 = new Attendance(participant3, LocalDate.of(2022, 7, 12), Status.PRESENT);
-        final Attendance attendance4 = new Attendance(participant4, LocalDate.of(2022, 7, 12), Status.PRESENT);
-        final Attendance attendance5 = new Attendance(participant5, LocalDate.of(2022, 7, 12), Status.PRESENT);
-        final Attendance attendance6 = new Attendance(participant6, LocalDate.of(2022, 7, 12), Status.PRESENT);
-        final Attendance attendance7 = new Attendance(participant7, LocalDate.of(2022, 7, 12), Status.PRESENT);
+        final Attendance attendance1 = new Attendance(participant1, LocalDate.of(2022, 7, 12), false, Status.TARDY);
+        final Attendance attendance2 = new Attendance(participant2, LocalDate.of(2022, 7, 12), false, Status.TARDY);
+        final Attendance attendance3 = new Attendance(participant3, LocalDate.of(2022, 7, 12), false, Status.PRESENT);
+        final Attendance attendance4 = new Attendance(participant4, LocalDate.of(2022, 7, 12), false, Status.PRESENT);
+        final Attendance attendance5 = new Attendance(participant5, LocalDate.of(2022, 7, 12), false, Status.PRESENT);
+        final Attendance attendance6 = new Attendance(participant6, LocalDate.of(2022, 7, 12), false, Status.PRESENT);
+        final Attendance attendance7 = new Attendance(participant7, LocalDate.of(2022, 7, 12), false, Status.PRESENT);
 
-        final Attendance attendance8 = new Attendance(participant1, LocalDate.of(2022, 7, 13), Status.PRESENT);
-        final Attendance attendance9 = new Attendance(participant2, LocalDate.of(2022, 7, 13), Status.TARDY);
-        final Attendance attendance10 = new Attendance(participant3, LocalDate.of(2022, 7, 13), Status.PRESENT);
-        final Attendance attendance11 = new Attendance(participant4, LocalDate.of(2022, 7, 13), Status.PRESENT);
-        final Attendance attendance12 = new Attendance(participant5, LocalDate.of(2022, 7, 13), Status.PRESENT);
-        final Attendance attendance13 = new Attendance(participant6, LocalDate.of(2022, 7, 13), Status.PRESENT);
-        final Attendance attendance14 = new Attendance(participant7, LocalDate.of(2022, 7, 13), Status.PRESENT);
+        final Attendance attendance8 = new Attendance(participant1, LocalDate.of(2022, 7, 13), false, Status.PRESENT);
+        final Attendance attendance9 = new Attendance(participant2, LocalDate.of(2022, 7, 13), false, Status.TARDY);
+        final Attendance attendance10 = new Attendance(participant3, LocalDate.of(2022, 7, 13), false, Status.PRESENT);
+        final Attendance attendance11 = new Attendance(participant4, LocalDate.of(2022, 7, 13), false, Status.PRESENT);
+        final Attendance attendance12 = new Attendance(participant5, LocalDate.of(2022, 7, 13), false, Status.PRESENT);
+        final Attendance attendance13 = new Attendance(participant6, LocalDate.of(2022, 7, 13), false, Status.PRESENT);
+        final Attendance attendance14 = new Attendance(participant7, LocalDate.of(2022, 7, 13), false, Status.PRESENT);
 
-        final Attendance attendance15 = new Attendance(participant1, LocalDate.of(2022, 7, 14), Status.PRESENT);
-        final Attendance attendance16 = new Attendance(participant2, LocalDate.of(2022, 7, 14), Status.TARDY);
-        final Attendance attendance17 = new Attendance(participant3, LocalDate.of(2022, 7, 14), Status.PRESENT);
-        final Attendance attendance18 = new Attendance(participant4, LocalDate.of(2022, 7, 14), Status.PRESENT);
-        final Attendance attendance19 = new Attendance(participant5, LocalDate.of(2022, 7, 14), Status.PRESENT);
-        final Attendance attendance20 = new Attendance(participant6, LocalDate.of(2022, 7, 14), Status.PRESENT);
-        final Attendance attendance21 = new Attendance(participant7, LocalDate.of(2022, 7, 14), Status.PRESENT);
+        final Attendance attendance15 = new Attendance(participant1, LocalDate.of(2022, 7, 14), false, Status.PRESENT);
+        final Attendance attendance16 = new Attendance(participant2, LocalDate.of(2022, 7, 14), false, Status.TARDY);
+        final Attendance attendance17 = new Attendance(participant3, LocalDate.of(2022, 7, 14), false, Status.PRESENT);
+        final Attendance attendance18 = new Attendance(participant4, LocalDate.of(2022, 7, 14), false, Status.PRESENT);
+        final Attendance attendance19 = new Attendance(participant5, LocalDate.of(2022, 7, 14), false, Status.PRESENT);
+        final Attendance attendance20 = new Attendance(participant6, LocalDate.of(2022, 7, 14), false, Status.PRESENT);
+        final Attendance attendance21 = new Attendance(participant7, LocalDate.of(2022, 7, 14), false, Status.PRESENT);
 
         attendanceRepository.save(attendance1);
         attendanceRepository.save(attendance2);

--- a/backend/src/main/java/com/woowacourse/moragora/controller/AttendanceController.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/AttendanceController.java
@@ -6,6 +6,7 @@ import com.woowacourse.moragora.dto.UserAttendanceRequest;
 import com.woowacourse.moragora.service.AttendanceService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,4 +29,12 @@ public class AttendanceController {
         attendanceService.updateAttendance(meetingId, userId, request);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/meetings/{meetingId}/coffees/use")
+    public ResponseEntity<Void> useCoffeeStack(@PathVariable final Long meetingId,
+                                               @AuthenticationPrincipal final Long loginId) {
+        attendanceService.disableUsedTardy(meetingId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/MeetingResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/MeetingResponse.java
@@ -1,6 +1,7 @@
 package com.woowacourse.moragora.dto;
 
 import com.woowacourse.moragora.entity.Meeting;
+import com.woowacourse.moragora.entity.MeetingAttendances;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -19,6 +20,7 @@ public class MeetingResponse {
     private final LocalDate endDate;
     private final String entranceTime;
     private final String leaveTime;
+    private final Boolean isCoffeeTime;
     private final List<ParticipantResponse> users;
 
     public MeetingResponse(final Long id,
@@ -28,7 +30,7 @@ public class MeetingResponse {
                            final LocalDate endDate,
                            final LocalTime entranceTime,
                            final LocalTime leaveTime,
-                           final List<ParticipantResponse> usersResponse) {
+                           final Boolean isCoffeeTime, final List<ParticipantResponse> usersResponse) {
         this.id = id;
         this.name = name;
         this.attendanceCount = attendanceCount;
@@ -36,20 +38,22 @@ public class MeetingResponse {
         this.endDate = endDate;
         this.entranceTime = entranceTime.format(TIME_FORMATTER);
         this.leaveTime = leaveTime.format(TIME_FORMATTER);
+        this.isCoffeeTime = isCoffeeTime;
         this.users = usersResponse;
     }
 
     public static MeetingResponse of(final Meeting meeting,
                                      final List<ParticipantResponse> participantResponses,
-                                     final long meetingAttendanceCount) {
+                                     final MeetingAttendances meetingAttendances) {
         return new MeetingResponse(
                 meeting.getId(),
                 meeting.getName(),
-                meetingAttendanceCount,
+                meetingAttendances.countProceedDate(),
                 meeting.getStartDate(),
                 meeting.getEndDate(),
                 meeting.getEntranceTime(),
                 meeting.getLeaveTime(),
+                meetingAttendances.isTardyStackFull(),
                 participantResponses
         );
     }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/MyMeetingResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/MyMeetingResponse.java
@@ -19,6 +19,7 @@ public class MyMeetingResponse {
     private final String entranceTime;
     private final String closingTime;
     private final int tardyCount;
+    private final Boolean isCoffeeTime;
 
     public MyMeetingResponse(final Long id,
                              final String name,
@@ -27,7 +28,8 @@ public class MyMeetingResponse {
                              final LocalDate endDate,
                              final LocalTime entranceTime,
                              final LocalTime closingTime,
-                             final int tardyCount) {
+                             final int tardyCount,
+                             final Boolean isCoffeeTime) {
         this.id = id;
         this.name = name;
         this.isActive = isActive;
@@ -36,12 +38,14 @@ public class MyMeetingResponse {
         this.entranceTime = entranceTime.format(TIME_FORMATTER);
         this.closingTime = closingTime.format(TIME_FORMATTER);
         this.tardyCount = tardyCount;
+        this.isCoffeeTime = isCoffeeTime;
     }
 
     public static MyMeetingResponse of(final Meeting meeting,
                                        final boolean isActive,
                                        final LocalTime closingTime,
-                                       final int tardyCount) {
+                                       final int tardyCount,
+                                       final boolean isCoffeeTime) {
 
         return new MyMeetingResponse(
                 meeting.getId(),
@@ -51,7 +55,8 @@ public class MyMeetingResponse {
                 meeting.getEndDate(),
                 meeting.getEntranceTime(),
                 closingTime,
-                tardyCount
+                tardyCount,
+                isCoffeeTime
         );
     }
 

--- a/backend/src/main/java/com/woowacourse/moragora/entity/Attendance.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/Attendance.java
@@ -1,6 +1,7 @@
 package com.woowacourse.moragora.entity;
 
 import java.time.LocalDate;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -32,11 +33,28 @@ public class Attendance {
     @Enumerated(EnumType.STRING)
     private Status status;
 
+    @Column(columnDefinition = "boolean default false")
+    private Boolean disabled;
+
+    public Attendance(final Long id,
+                      final Participant participant,
+                      final LocalDate attendanceDate,
+                      final Boolean disabled,
+                      final Status status) {
+        this.id = id;
+        this.participant = participant;
+        this.attendanceDate = attendanceDate;
+        this.disabled = disabled;
+        this.status = status;
+    }
+
     public Attendance(final Participant participant,
                       final LocalDate attendanceDate,
+                      final Boolean disabled,
                       final Status status) {
         this.participant = participant;
         this.attendanceDate = attendanceDate;
+        this.disabled = disabled;
         this.status = status;
     }
 
@@ -44,8 +62,16 @@ public class Attendance {
         this.status = status;
     }
 
-    public boolean isSameStatus(final Status status) {
-        return this.status == status;
+    public void disable() {
+        disabled = true;
+    }
+
+    public boolean isTardy() {
+        return this.status == Status.TARDY;
+    }
+
+    public boolean isEnabled() {
+        return !disabled;
     }
 
     public boolean isSameDate(final LocalDate date) {

--- a/backend/src/main/java/com/woowacourse/moragora/entity/MeetingAttendances.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/MeetingAttendances.java
@@ -7,10 +7,12 @@ import java.util.stream.Collectors;
 public class MeetingAttendances {
 
     private final List<Attendance> values;
+    private final int numberOfParticipants;
 
-    public MeetingAttendances(final List<Attendance> values) {
+    public MeetingAttendances(final List<Attendance> values, final int numberOfParticipants) {
         validateSingleMeeting(values);
         this.values = values;
+        this.numberOfParticipants = numberOfParticipants;
     }
 
     public ParticipantAttendances extractAttendancesByParticipant(final Participant participant) {
@@ -20,7 +22,7 @@ public class MeetingAttendances {
         return new ParticipantAttendances(attendances);
     }
 
-    public long extractProceedDate() {
+    public long countProceedDate() {
         return values.stream()
                 .map(Attendance::getAttendanceDate)
                 .distinct()
@@ -32,6 +34,10 @@ public class MeetingAttendances {
                 .filter(Attendance::isEnabled)
                 .filter(Attendance::isTardy)
                 .count();
+    }
+
+    public boolean isTardyStackFull() {
+        return countTardy() >= numberOfParticipants;
     }
 
     public void disableAttendances(final int disableSize) {

--- a/backend/src/main/java/com/woowacourse/moragora/entity/MeetingAttendances.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/MeetingAttendances.java
@@ -1,5 +1,6 @@
 package com.woowacourse.moragora.entity;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -13,7 +14,7 @@ public class MeetingAttendances {
     }
 
     public ParticipantAttendances extractAttendancesByParticipant(final Participant participant) {
-        final List<Attendance> attendances = this.values.stream()
+        final List<Attendance> attendances = values.stream()
                 .filter(attendance -> attendance.getParticipant().equals(participant))
                 .collect(Collectors.toList());
         return new ParticipantAttendances(attendances);
@@ -24,6 +25,24 @@ public class MeetingAttendances {
                 .map(Attendance::getAttendanceDate)
                 .distinct()
                 .count();
+    }
+
+    public int countTardy() {
+        return (int) values.stream()
+                .filter(Attendance::isEnabled)
+                .filter(Attendance::isTardy)
+                .count();
+    }
+
+    public void disableAttendances(final int disableSize) {
+        final List<Attendance> filteredAttendances = values.stream()
+                .filter(Attendance::isEnabled)
+                .filter(Attendance::isTardy)
+                .limit(disableSize)
+                .sorted(Comparator.comparingLong(Attendance::getId))
+                .collect(Collectors.toList());
+
+        filteredAttendances.forEach(Attendance::disable);
     }
 
     private void validateSingleMeeting(final List<Attendance> value) {

--- a/backend/src/main/java/com/woowacourse/moragora/entity/ParticipantAttendances.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/ParticipantAttendances.java
@@ -25,7 +25,8 @@ public class ParticipantAttendances {
 
     public int countTardy(final boolean isAttendanceClosed, final LocalDate today) {
         final Stream<Attendance> attendances = values.stream()
-                .filter(it -> it.isSameStatus(Status.TARDY));
+                .filter(Attendance::isEnabled)
+                .filter(Attendance::isTardy);
 
         if (isAttendanceClosed) {
             return (int) attendances.count();

--- a/backend/src/main/java/com/woowacourse/moragora/exception/InvalidCoffeeTimeException.java
+++ b/backend/src/main/java/com/woowacourse/moragora/exception/InvalidCoffeeTimeException.java
@@ -1,0 +1,12 @@
+package com.woowacourse.moragora.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidCoffeeTimeException extends ClientRuntimeException {
+
+    private static final String MESSAGE = "커피 스택이 충분히 쌓이지 않았습니다.";
+
+    public InvalidCoffeeTimeException() {
+        super(MESSAGE, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/moragora/service/AttendanceService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/AttendanceService.java
@@ -3,8 +3,10 @@ package com.woowacourse.moragora.service;
 import com.woowacourse.moragora.dto.UserAttendanceRequest;
 import com.woowacourse.moragora.entity.Attendance;
 import com.woowacourse.moragora.entity.Meeting;
+import com.woowacourse.moragora.entity.MeetingAttendances;
 import com.woowacourse.moragora.entity.Participant;
 import com.woowacourse.moragora.entity.user.User;
+import com.woowacourse.moragora.exception.InvalidCoffeeTimeException;
 import com.woowacourse.moragora.exception.meeting.AttendanceNotFoundException;
 import com.woowacourse.moragora.exception.meeting.ClosingTimeExcessException;
 import com.woowacourse.moragora.exception.meeting.MeetingNotFoundException;
@@ -16,6 +18,8 @@ import com.woowacourse.moragora.repository.ParticipantRepository;
 import com.woowacourse.moragora.repository.UserRepository;
 import com.woowacourse.moragora.support.ServerTimeManager;
 import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,11 +66,32 @@ public class AttendanceService {
         attendance.changeAttendanceStatus(request.getAttendanceStatus());
     }
 
+    @Transactional
+    public void disableUsedTardy(final Long meetingId) {
+        final Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(MeetingNotFoundException::new);
+        final List<Participant> participants = meeting.getParticipants();
+        final List<Long> participantIds = participants.stream()
+                .map(Participant::getId)
+                .collect(Collectors.toList());
+        final List<Attendance> attendances = attendanceRepository.findByParticipantIdIn(participantIds);
+        final MeetingAttendances meetingAttendances = new MeetingAttendances(attendances);
+        validateCanUse(participants.size(), meetingAttendances);
+        meetingAttendances.disableAttendances(participants.size());
+    }
+
     private void validateAttendanceTime(final Meeting meeting) {
         final LocalTime entranceTime = meeting.getEntranceTime();
 
         if (serverTimeManager.isOverClosingTime(entranceTime)) {
             throw new ClosingTimeExcessException();
+        }
+    }
+
+    private void validateCanUse(final int numberOfParticipants, final MeetingAttendances attendances) {
+        final int tardyCount = attendances.countTardy();
+        if (tardyCount < numberOfParticipants) {
+            throw new InvalidCoffeeTimeException();
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/service/AttendanceService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/AttendanceService.java
@@ -75,7 +75,7 @@ public class AttendanceService {
                 .map(Participant::getId)
                 .collect(Collectors.toList());
         final List<Attendance> attendances = attendanceRepository.findByParticipantIdIn(participantIds);
-        final MeetingAttendances meetingAttendances = new MeetingAttendances(attendances);
+        final MeetingAttendances meetingAttendances = new MeetingAttendances(attendances, participants.size());
         validateCanUse(participants.size(), meetingAttendances);
         meetingAttendances.disableAttendances(participants.size());
     }

--- a/backend/src/main/java/com/woowacourse/moragora/service/AttendanceService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/AttendanceService.java
@@ -76,7 +76,7 @@ public class AttendanceService {
                 .collect(Collectors.toList());
         final List<Attendance> attendances = attendanceRepository.findByParticipantIdIn(participantIds);
         final MeetingAttendances meetingAttendances = new MeetingAttendances(attendances, participants.size());
-        validateCanUse(participants.size(), meetingAttendances);
+        validateEnoughTardyCountToDisable(meetingAttendances);
         meetingAttendances.disableAttendances(participants.size());
     }
 
@@ -88,9 +88,8 @@ public class AttendanceService {
         }
     }
 
-    private void validateCanUse(final int numberOfParticipants, final MeetingAttendances attendances) {
-        final int tardyCount = attendances.countTardy();
-        if (tardyCount < numberOfParticipants) {
+    private void validateEnoughTardyCountToDisable(final MeetingAttendances attendances) {
+        if (!attendances.isTardyStackFull()) {
             throw new InvalidCoffeeTimeException();
         }
     }

--- a/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
@@ -91,7 +91,7 @@ public class MeetingService {
                         meetingAttendances, isOver, participant))
                 .collect(Collectors.toList());
 
-        return MeetingResponse.of(meeting, participantResponses, meetingAttendances.extractProceedDate());
+        return MeetingResponse.of(meeting, participantResponses, meetingAttendances);
     }
 
 
@@ -131,7 +131,7 @@ public class MeetingService {
 
     private void saveAttendances(final List<Participant> participants, final LocalDate today) {
         for (final Participant participant : participants) {
-            attendanceRepository.save(new Attendance(participant, today, Status.TARDY));
+            attendanceRepository.save(new Attendance(participant, today, false, Status.TARDY));
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
@@ -152,7 +152,7 @@ public class MeetingService {
                 .map(Participant::getId)
                 .collect(Collectors.toList());
         final List<Attendance> foundAttendances = attendanceRepository.findByParticipantIdIn(participantIds);
-        return new MeetingAttendances(foundAttendances);
+        return new MeetingAttendances(foundAttendances, participants.size());
     }
 
     private ParticipantResponse generateParticipantResponse(final LocalDateTime now,
@@ -178,6 +178,6 @@ public class MeetingService {
         final LocalTime closingTime = serverTimeManager.calculateClosingTime(meeting.getEntranceTime());
         final int tardyCount = participantAttendances.countTardy(isOver, serverTimeManager.getDate());
 
-        return MyMeetingResponse.of(meeting, isActive, closingTime, tardyCount);
+        return MyMeetingResponse.of(meeting, isActive, closingTime, tardyCount, meetingAttendances.isTardyStackFull());
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/AcceptanceTest.java
@@ -59,6 +59,16 @@ public class AcceptanceTest {
                 .then().log().all();
     }
 
+    protected ValidatableResponse put(final String uri, final Object requestBody, final String token) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(token)
+                .body(requestBody)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().put(uri)
+                .then().log().all();
+    }
+
     protected String signUpAndGetToken() {
         final String email = "test@naver.com";
         final String password = "1234asdfg!";

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/AttendanceAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/AttendanceAcceptanceTest.java
@@ -37,12 +37,35 @@ class AttendanceAcceptanceTest extends AcceptanceTest {
                 .willReturn(dateTime.toLocalDate());
 
         // when
+        final ValidatableResponse response = put("/meetings/" + meetingId + "/users/" + userId,
+                userAttendanceRequest, signUpAndGetToken());
+
+        // then
+        response.statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @DisplayName("모임에 쌓인 커피스택을 사용하면 참가자들의 커피 스택을 차감하고 상태코드 204을 반환한다.")
+    @Test
+    void useCoffeeStack() {
+        // given
+        final int meetingId = 1;
+        final String token = signUpAndGetToken();
+
+        final LocalDateTime dateTime = LocalDateTime.of(2022, 7, 15, 0, 0);
+        given(serverTimeManager.isOverClosingTime(any(LocalTime.class)))
+                .willReturn(false);
+        given(serverTimeManager.getDateAndTime())
+                .willReturn(dateTime);
+        given(serverTimeManager.getDate())
+                .willReturn(dateTime.toLocalDate());
+        get("/meetings/" + meetingId, token);
+
+        // when
         final ValidatableResponse response = RestAssured.given().log().all()
-                .auth().oauth2(signUpAndGetToken())
-                .body(userAttendanceRequest)
+                .auth().oauth2(token)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
-                .when().put("/meetings/" + meetingId + "/users/" + userId)
+                .when().post("/meetings/" + meetingId + "/coffees/use")
                 .then().log().all();
 
         // then

--- a/backend/src/test/java/com/woowacourse/moragora/controller/AttendanceControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/AttendanceControllerTest.java
@@ -83,4 +83,21 @@ class AttendanceControllerTest extends ControllerTest {
         // then
         resultActions.andExpect(status().isNotFound());
     }
+
+    @DisplayName("모임의 커피스택을 비운다.")
+    @Test
+    void useCoffeeStack() throws Exception {
+        // given
+        final Long meetingId = 1L;
+        final Long userId = 1L;
+        final UserAttendanceRequest request = new UserAttendanceRequest(Status.PRESENT);
+        validateToken("1");
+        performPut("/meetings/" + meetingId + "/users/" + userId, request);
+
+        // when
+        final ResultActions resultActions = performPost("/meetings/" + meetingId + "/coffees/use");
+
+        // then
+        resultActions.andExpect(status().isNoContent());
+    }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/controller/ControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/ControllerTest.java
@@ -57,6 +57,12 @@ public class ControllerTest {
                 .andDo(print());
     }
 
+    protected ResultActions performPost(final String uri) throws Exception {
+        return mockMvc.perform(post(uri)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+    }
+
     protected ResultActions performGet(final String uri) throws Exception {
         return mockMvc.perform(MockMvcRequestBuilders.get(uri)
                         .accept(MediaType.APPLICATION_JSON))

--- a/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
@@ -277,7 +277,7 @@ class MeetingControllerTest extends ControllerTest {
         final LocalTime entranceTime = LocalTime.of(10, 0);
         final LocalTime leaveTime = LocalTime.of(18, 0);
         final MeetingResponse meetingResponse = new MeetingResponse(id, name, attendanceCount, startDate, endDate,
-                entranceTime, leaveTime, participantResponses
+                entranceTime, leaveTime, false, participantResponses
         );
 
         validateToken("1");
@@ -311,6 +311,7 @@ class MeetingControllerTest extends ControllerTest {
                                 fieldWithPath("endDate").type(JsonFieldType.STRING).description(endDate),
                                 fieldWithPath("entranceTime").type(JsonFieldType.STRING).description(entranceTime),
                                 fieldWithPath("leaveTime").type(JsonFieldType.STRING).description(leaveTime),
+                                fieldWithPath("isCoffeeTime").type(JsonFieldType.BOOLEAN).description(false),
                                 fieldWithPath("users[].id").type(JsonFieldType.NUMBER).description(1L),
                                 fieldWithPath("users[].email").type(JsonFieldType.STRING).description("abc@email.com"),
                                 fieldWithPath("users[].nickname").type(JsonFieldType.STRING).description("foo"),
@@ -331,14 +332,14 @@ class MeetingControllerTest extends ControllerTest {
                         LocalDate.of(2022, 7, 10),
                         LocalDate.of(2022, 8, 10),
                         LocalTime.of(10, 0),
-                        LocalTime.of(10, 5), 1);
+                        LocalTime.of(10, 5), 1, false);
 
         final MyMeetingResponse myMeetingResponse2 =
                 new MyMeetingResponse(2L, "모임2", true,
                         LocalDate.of(2022, 7, 15),
                         LocalDate.of(2022, 8, 15),
                         LocalTime.of(9, 0),
-                        LocalTime.of(9, 5), 2);
+                        LocalTime.of(9, 5), 2, false);
 
         final MyMeetingsResponse meetingsResponse =
                 MyMeetingsResponse.of(now, List.of(myMeetingResponse, myMeetingResponse2));
@@ -362,6 +363,7 @@ class MeetingControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.meetings[*].entranceTime", containsInAnyOrder("09:00", "10:00")))
                 .andExpect(jsonPath("$.meetings[*].closingTime", containsInAnyOrder("09:05", "10:05")))
                 .andExpect(jsonPath("$.meetings[*].tardyCount", containsInAnyOrder(1, 2)))
+                .andExpect(jsonPath("$.meetings[*].isCoffeeTime", containsInAnyOrder(false, false)))
                 .andDo(document("meeting/find-my-meetings",
                         responseFields(
                                 fieldWithPath("serverTime").type(JsonFieldType.NUMBER)
@@ -378,8 +380,9 @@ class MeetingControllerTest extends ControllerTest {
                                 fieldWithPath("meetings[].closingTime").type(JsonFieldType.STRING)
                                         .description("09:05"),
                                 fieldWithPath("meetings[].tardyCount").type(JsonFieldType.NUMBER)
-                                        .description(1)
-
+                                        .description(1),
+                                fieldWithPath("meetings[].isCoffeeTime").type(JsonFieldType.BOOLEAN)
+                                        .description(false)
                         )
                 ));
     }

--- a/backend/src/test/java/com/woowacourse/moragora/entity/MeetingAttendancesTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/entity/MeetingAttendancesTest.java
@@ -42,7 +42,7 @@ class MeetingAttendancesTest {
         final Attendance attendance3 = new Attendance(participant3, date, false, Status.fromEnum(status3));
 
         final MeetingAttendances meetingAttendances = new MeetingAttendances(
-                List.of(attendance1, attendance2, attendance3));
+                List.of(attendance1, attendance2, attendance3), 3);
 
         // when
         final int actual = meetingAttendances.countTardy();
@@ -73,7 +73,7 @@ class MeetingAttendancesTest {
         final Attendance attendance3 = new Attendance(3L, participant3, date, false, Status.TARDY);
 
         final List<Attendance> attendances = List.of(attendance1, attendance2, attendance3);
-        final MeetingAttendances meetingAttendances = new MeetingAttendances(attendances);
+        final MeetingAttendances meetingAttendances = new MeetingAttendances(attendances, 3);
 
         // when
         meetingAttendances.disableAttendances(sizeToDisable);

--- a/backend/src/test/java/com/woowacourse/moragora/entity/MeetingAttendancesTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/entity/MeetingAttendancesTest.java
@@ -1,0 +1,84 @@
+package com.woowacourse.moragora.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.moragora.entity.user.EncodedPassword;
+import com.woowacourse.moragora.entity.user.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MeetingAttendancesTest {
+
+    @DisplayName("미팅 내에서 현재 활성화된 지각 횟수를 반환한다.")
+    @ParameterizedTest
+    @CsvSource(value = {
+            "TARDY,TARDY,TARDY,3",
+            "TARDY,TARDY,PRESENT,2",
+            "TARDY,PRESENT,PRESENT,1",
+            "PRESENT,PRESENT,PRESENT,0"
+    })
+    void countTardy(final String status1, final String status2, final String status3, final int expected) {
+        // given
+        final EncodedPassword encodedPassword = EncodedPassword.fromRawValue("qwer1234!");
+        final LocalDateTime now = LocalDateTime.now();
+        final LocalDate date = now.toLocalDate();
+        final LocalTime time = now.toLocalTime();
+        final User user1 = new User("sun@gmail.com", encodedPassword, "sun");
+        final User user2 = new User("kun@gmail.com", encodedPassword, "kun");
+        final User user3 = new User("forki@gmail.com", encodedPassword, "forki");
+        final Meeting meeting = new Meeting("미팅1", date, date, time, time);
+        final Participant participant1 = new Participant(user1, meeting);
+        final Participant participant2 = new Participant(user2, meeting);
+        final Participant participant3 = new Participant(user3, meeting);
+
+        final Attendance attendance1 = new Attendance(participant1, date, false, Status.fromEnum(status1));
+        final Attendance attendance2 = new Attendance(participant2, date, false, Status.fromEnum(status2));
+        final Attendance attendance3 = new Attendance(participant3, date, false, Status.fromEnum(status3));
+
+        final MeetingAttendances meetingAttendances = new MeetingAttendances(
+                List.of(attendance1, attendance2, attendance3));
+
+        // when
+        final int actual = meetingAttendances.countTardy();
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @DisplayName("비활성화할 개수만큼 출석부의 데이터를 비활성화한다.")
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3})
+    void disableAttendances(final int sizeToDisable) {
+        // given
+        final EncodedPassword encodedPassword = EncodedPassword.fromRawValue("qwer1234!");
+        final LocalDateTime now = LocalDateTime.now();
+        final LocalDate date = now.toLocalDate();
+        final LocalTime time = now.toLocalTime();
+        final User user1 = new User("sun@gmail.com", encodedPassword, "sun");
+        final User user2 = new User("kun@gmail.com", encodedPassword, "kun");
+        final User user3 = new User("forki@gmail.com", encodedPassword, "forki");
+        final Meeting meeting = new Meeting("미팅1", date, date, time, time);
+        final Participant participant1 = new Participant(user1, meeting);
+        final Participant participant2 = new Participant(user2, meeting);
+        final Participant participant3 = new Participant(user3, meeting);
+
+        final Attendance attendance1 = new Attendance(1L, participant1, date, false, Status.TARDY);
+        final Attendance attendance2 = new Attendance(2L, participant2, date, false, Status.TARDY);
+        final Attendance attendance3 = new Attendance(3L, participant3, date, false, Status.TARDY);
+
+        final List<Attendance> attendances = List.of(attendance1, attendance2, attendance3);
+        final MeetingAttendances meetingAttendances = new MeetingAttendances(attendances);
+
+        // when
+        meetingAttendances.disableAttendances(sizeToDisable);
+
+        // then
+        assertThat(meetingAttendances.countTardy()).isEqualTo(attendances.size() - sizeToDisable);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/moragora/service/AttendanceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/AttendanceServiceTest.java
@@ -91,4 +91,22 @@ class AttendanceServiceTest {
         assertThatThrownBy(() -> attendanceService.updateAttendance(1L, 1L, request))
                 .isInstanceOf(ClosingTimeExcessException.class);
     }
+
+    @DisplayName("사용된 커피스택을 비활성화한다.")
+    @Test
+    void disableUsedTardy() {
+        // given
+        final Long meetingId = 1L;
+
+        final LocalDateTime dateTime1 = LocalDateTime.of(2022, 7, 14, 10, 10);
+        serverTimeManager.refresh(dateTime1);
+        meetingService.findById(meetingId);
+        final LocalDateTime dateTime2 = LocalDateTime.of(2022, 7, 15, 10, 10);
+        serverTimeManager.refresh(dateTime2);
+        meetingService.findById(meetingId);
+
+        // when, then
+        assertThatCode(() -> attendanceService.disableUsedTardy(meetingId))
+                .doesNotThrowAnyException();
+    }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
@@ -140,7 +140,7 @@ class MeetingServiceTest {
                 LocalDate.of(2022, 8, 10),
                 LocalTime.of(10, 0),
                 LocalTime.of(18, 0),
-                null
+                false, null
         );
 
         final LocalDateTime dateTime = LocalDateTime.of(2022, 7, 14, 0, 0);
@@ -168,7 +168,7 @@ class MeetingServiceTest {
                 LocalDate.of(2022, 8, 10),
                 LocalTime.of(10, 0),
                 LocalTime.of(18, 0),
-                null
+                true, null
         );
 
         // when
@@ -193,15 +193,15 @@ class MeetingServiceTest {
                 LocalDate.of(2022, 8, 10),
                 LocalTime.of(10, 0),
                 LocalTime.of(18, 0),
-                List.of(
-                        new ParticipantResponse(1L, "aaa111@foo.com", "아스피", Status.PRESENT, 1),
-                        new ParticipantResponse(2L, "bbb222@foo.com", "필즈", Status.TARDY, 2),
-                        new ParticipantResponse(3L, "ccc333@foo.com", "포키", Status.PRESENT, 0),
-                        new ParticipantResponse(4L, "ddd444@foo.com", "썬", Status.PRESENT, 0),
-                        new ParticipantResponse(5L, "eee555@foo.com", "우디", Status.PRESENT, 0),
-                        new ParticipantResponse(6L, "fff666@foo.com", "쿤", Status.PRESENT, 0),
-                        new ParticipantResponse(7L, "ggg777@foo.com", "반듯", Status.PRESENT, 0)
-                )
+                false, List.of(
+                new ParticipantResponse(1L, "aaa111@foo.com", "아스피", Status.PRESENT, 1),
+                new ParticipantResponse(2L, "bbb222@foo.com", "필즈", Status.TARDY, 2),
+                new ParticipantResponse(3L, "ccc333@foo.com", "포키", Status.PRESENT, 0),
+                new ParticipantResponse(4L, "ddd444@foo.com", "썬", Status.PRESENT, 0),
+                new ParticipantResponse(5L, "eee555@foo.com", "우디", Status.PRESENT, 0),
+                new ParticipantResponse(6L, "fff666@foo.com", "쿤", Status.PRESENT, 0),
+                new ParticipantResponse(7L, "ggg777@foo.com", "반듯", Status.PRESENT, 0)
+        )
         );
 
         final LocalDateTime dateTime = LocalDateTime.of(2022, 7, 14, 0, 0);
@@ -228,15 +228,15 @@ class MeetingServiceTest {
                 LocalDate.of(2022, 8, 10),
                 LocalTime.of(10, 0),
                 LocalTime.of(18, 0),
-                List.of(
-                        new ParticipantResponse(1L, "aaa111@foo.com", "아스피", Status.PRESENT, 1),
-                        new ParticipantResponse(2L, "bbb222@foo.com", "필즈", Status.TARDY, 3),
-                        new ParticipantResponse(3L, "ccc333@foo.com", "포키", Status.PRESENT, 0),
-                        new ParticipantResponse(4L, "ddd444@foo.com", "썬", Status.PRESENT, 0),
-                        new ParticipantResponse(5L, "eee555@foo.com", "우디", Status.PRESENT, 0),
-                        new ParticipantResponse(6L, "fff666@foo.com", "쿤", Status.PRESENT, 0),
-                        new ParticipantResponse(7L, "ggg777@foo.com", "반듯", Status.PRESENT, 0)
-                )
+                false, List.of(
+                new ParticipantResponse(1L, "aaa111@foo.com", "아스피", Status.PRESENT, 1),
+                new ParticipantResponse(2L, "bbb222@foo.com", "필즈", Status.TARDY, 3),
+                new ParticipantResponse(3L, "ccc333@foo.com", "포키", Status.PRESENT, 0),
+                new ParticipantResponse(4L, "ddd444@foo.com", "썬", Status.PRESENT, 0),
+                new ParticipantResponse(5L, "eee555@foo.com", "우디", Status.PRESENT, 0),
+                new ParticipantResponse(6L, "fff666@foo.com", "쿤", Status.PRESENT, 0),
+                new ParticipantResponse(7L, "ggg777@foo.com", "반듯", Status.PRESENT, 0)
+        )
         );
 
         final LocalDateTime dateTime = LocalDateTime.of(2022, 7, 14, 10, 5, 1);
@@ -285,9 +285,9 @@ class MeetingServiceTest {
                         serverTimeManager.getDateAndTime(),
                         List.of(
                                 MyMeetingResponse.of(meeting, false,
-                                        serverTimeManager.calculateClosingTime(entranceTime), 1),
+                                        serverTimeManager.calculateClosingTime(entranceTime), 1, false),
                                 MyMeetingResponse.of(meetingRequest.toEntity(), false,
-                                        serverTimeManager.calculateClosingTime(entranceTime), 0)
+                                        serverTimeManager.calculateClosingTime(entranceTime), 0, false)
                         ))
                 );
     }


### PR DESCRIPTION
Close #210 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/coffee-stack-use -> dev

## 요구사항
- 커피 스택 비우기 기능 구현

## 변경사항
- 커피 스택 비우기 기능 구현
- 전체 미팅 리스트 조회에 `isCoffeeTime` 필드 추가
- 단일 미팅 조회에 `isCoffeeTime` 필드 추가
- `Attendance`에 `disabled` 필드 추가


