### PR TITLE
[BE] 커피 비우기 전 소비할 내역 조회하기 기능

### DIFF
--- a/backend/src/docs/asciidoc/meeting.asciidoc
+++ b/backend/src/docs/asciidoc/meeting.asciidoc
@@ -72,3 +72,31 @@ include::{snippets}/meeting/enter-Attendance/http-response.adoc[]
 === Request fields
 
 include::{snippets}/meeting/enter-Attendance/request-fields.adoc[]
+
+[[showUserCoffeeStats]]
+== 유저별 사용할 커피 스택 수 조회
+
+[[showUserCoffeeStats-success]]
+=== HTTP request
+
+include::{snippets}/meeting/usable-coffee/http-request.adoc[]
+
+=== HTTP response
+
+include::{snippets}/meeting/usable-coffee/http-response.adoc[]
+
+=== Response fields
+
+include::{snippets}/meeting/usable-coffee/response-fields.adoc[]
+
+[[useCoffeeStack]]
+== 커피스택 비우기
+
+[[useCoffeeStack-success]]
+=== HTTP request
+
+include::{snippets}/meeting/use-coffee/http-request.adoc[]
+
+=== HTTP response
+
+include::{snippets}/meeting/use-coffee/http-response.adoc[]

--- a/backend/src/main/java/com/woowacourse/moragora/controller/AttendanceController.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/AttendanceController.java
@@ -3,9 +3,11 @@ package com.woowacourse.moragora.controller;
 import com.woowacourse.auth.support.Authentication;
 import com.woowacourse.auth.support.AuthenticationPrincipal;
 import com.woowacourse.auth.support.MasterAuthorization;
+import com.woowacourse.moragora.dto.CoffeeStatsResponse;
 import com.woowacourse.moragora.dto.UserAttendanceRequest;
 import com.woowacourse.moragora.service.AttendanceService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -32,6 +34,12 @@ public class AttendanceController {
         return ResponseEntity.noContent().build();
     }
 
+    @GetMapping("/meetings/{meetingId}/coffees/use")
+    public ResponseEntity<CoffeeStatsResponse> showUserCoffeeStats(@PathVariable final Long meetingId) {
+        final CoffeeStatsResponse response = attendanceService.countUsableCoffeeStack(meetingId);
+        return ResponseEntity.ok(response);
+    }
+
     @MasterAuthorization
     @PostMapping("/meetings/{meetingId}/coffees/use")
     public ResponseEntity<Void> useCoffeeStack(@PathVariable final Long meetingId,
@@ -39,5 +47,4 @@ public class AttendanceController {
         attendanceService.disableUsedTardy(meetingId);
         return ResponseEntity.noContent().build();
     }
-
 }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/CoffeeStatResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/CoffeeStatResponse.java
@@ -10,15 +10,15 @@ public class CoffeeStatResponse {
 
     private final Long id;
     private final String nickname;
-    private final int coffeeCount;
+    private final Long coffeeCount;
 
-    public CoffeeStatResponse(final Long id, final String nickname, final int coffeeCount) {
+    public CoffeeStatResponse(final Long id, final String nickname, final Long coffeeCount) {
         this.id = id;
         this.nickname = nickname;
         this.coffeeCount = coffeeCount;
     }
 
-    public static CoffeeStatResponse of(final User user, final int coffeeCount) {
+    public static CoffeeStatResponse of(final User user, final Long coffeeCount) {
         return new CoffeeStatResponse(
                 user.getId(), user.getNickname(), coffeeCount
         );

--- a/backend/src/main/java/com/woowacourse/moragora/dto/CoffeeStatResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/CoffeeStatResponse.java
@@ -2,8 +2,10 @@ package com.woowacourse.moragora.dto;
 
 import com.woowacourse.moragora.entity.user.User;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class CoffeeStatResponse {
 
     private final Long id;

--- a/backend/src/main/java/com/woowacourse/moragora/dto/CoffeeStatResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/CoffeeStatResponse.java
@@ -1,0 +1,24 @@
+package com.woowacourse.moragora.dto;
+
+import com.woowacourse.moragora.entity.user.User;
+import lombok.Getter;
+
+@Getter
+public class CoffeeStatResponse {
+
+    private final Long id;
+    private final String nickname;
+    private final int coffeeCount;
+
+    public CoffeeStatResponse(final Long id, final String nickname, final int coffeeCount) {
+        this.id = id;
+        this.nickname = nickname;
+        this.coffeeCount = coffeeCount;
+    }
+
+    public static CoffeeStatResponse of(final User user, final int coffeeCount) {
+        return new CoffeeStatResponse(
+                user.getId(), user.getNickname(), coffeeCount
+        );
+    }
+}

--- a/backend/src/main/java/com/woowacourse/moragora/dto/CoffeeStatsResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/CoffeeStatsResponse.java
@@ -19,7 +19,7 @@ public class CoffeeStatsResponse {
 
     public static CoffeeStatsResponse from(Map<User, Long> userCoffeeStats) {
         final List<CoffeeStatResponse> coffeeStatResponses = userCoffeeStats.keySet().stream()
-                .map(user -> CoffeeStatResponse.of(user, userCoffeeStats.get(user).intValue()))
+                .map(user -> CoffeeStatResponse.of(user, userCoffeeStats.get(user)))
                 .collect(Collectors.toList());
         return new CoffeeStatsResponse(coffeeStatResponses);
     }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/CoffeeStatsResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/CoffeeStatsResponse.java
@@ -1,0 +1,24 @@
+package com.woowacourse.moragora.dto;
+
+import com.woowacourse.moragora.entity.user.User;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+@Getter
+public class CoffeeStatsResponse {
+
+    private final List<CoffeeStatResponse> userCoffeeStats;
+
+    public CoffeeStatsResponse(final List<CoffeeStatResponse> userCoffeeStats) {
+        this.userCoffeeStats = List.copyOf(userCoffeeStats);
+    }
+
+    public static CoffeeStatsResponse from(Map<User, Long> userCoffeeStats) {
+        final List<CoffeeStatResponse> coffeeStatResponses = userCoffeeStats.keySet().stream()
+                .map(user -> CoffeeStatResponse.of(user, userCoffeeStats.get(user).intValue()))
+                .collect(Collectors.toList());
+        return new CoffeeStatsResponse(coffeeStatResponses);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/moragora/dto/CoffeeStatsResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/CoffeeStatsResponse.java
@@ -5,8 +5,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class CoffeeStatsResponse {
 
     private final List<CoffeeStatResponse> userCoffeeStats;

--- a/backend/src/main/java/com/woowacourse/moragora/entity/Attendance.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/Attendance.java
@@ -38,23 +38,14 @@ public class Attendance {
     @JoinColumn(name = "event_id")
     private Event event;
 
-    public Attendance(final Long id,
-                      final Status status,
-                      final Boolean disabled,
-                      final Participant participant,
-                      final Event event) {
-        this.id = id;
-        this.disabled = disabled;
-        this.status = status;
-        this.participant = participant;
-        this.event = event;
-    }
-
     public Attendance(final Status status,
                       final Boolean disabled,
                       final Participant participant,
                       final Event event) {
-        this(null, status, disabled, participant, event);
+        this.status = status;
+        this.disabled = disabled;
+        this.participant = participant;
+        this.event = event;
     }
 
     public void changeAttendanceStatus(final Status status) {

--- a/backend/src/main/java/com/woowacourse/moragora/entity/Meeting.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/Meeting.java
@@ -4,6 +4,7 @@ import com.woowacourse.moragora.exception.meeting.IllegalStartEndDateException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -46,5 +47,11 @@ public class Meeting {
         if (startDate.isAfter(endDate)) {
             throw new IllegalStartEndDateException();
         }
+    }
+
+    public List<Long> getParticipantIds() {
+        return participants.stream()
+                .map(Participant::getId)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/entity/MeetingAttendances.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/MeetingAttendances.java
@@ -65,7 +65,7 @@ public class MeetingAttendances {
         return values.stream()
                 .filter(Attendance::isEnabled)
                 .filter(Attendance::isTardy)
-                .sorted(Comparator.comparingLong(Attendance::getId))
+                .sorted(Comparator.comparing(attendance -> attendance.getEvent().getDate()))
                 .limit(numberOfParticipants)
                 .collect(Collectors.toList());
     }

--- a/backend/src/main/java/com/woowacourse/moragora/entity/user/User.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/user/User.java
@@ -39,12 +39,17 @@ public class User {
     @Column(nullable = false)
     private String nickname;
 
-    public User(final String email, final EncodedPassword password, final String nickname) {
+    public User(final Long id, final String email, final EncodedPassword password, final String nickname) {
         validateEmail(email);
         validateNickname(nickname);
+        this.id = id;
         this.email = email;
         this.password = password;
         this.nickname = nickname;
+    }
+
+    public User(final String email, final EncodedPassword password, final String nickname) {
+        this(null, email, password, nickname);
     }
 
     private void validateEmail(final String email) {

--- a/backend/src/main/java/com/woowacourse/moragora/service/AttendanceService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/AttendanceService.java
@@ -1,5 +1,6 @@
 package com.woowacourse.moragora.service;
 
+import com.woowacourse.moragora.dto.CoffeeStatsResponse;
 import com.woowacourse.moragora.dto.UserAttendanceRequest;
 import com.woowacourse.moragora.entity.Attendance;
 import com.woowacourse.moragora.entity.Event;
@@ -22,6 +23,7 @@ import com.woowacourse.moragora.repository.UserRepository;
 import com.woowacourse.moragora.support.ServerTimeManager;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -73,18 +75,18 @@ public class AttendanceService {
         attendance.changeAttendanceStatus(request.getAttendanceStatus());
     }
 
+    public CoffeeStatsResponse countUsableCoffeeStack(final Long meetingId) {
+        final MeetingAttendances meetingAttendances = findMeetingAttendancesBy(meetingId);
+        validateEnoughTardyCountToDisable(meetingAttendances);
+        final Map<User, Long> userCoffeeStats = meetingAttendances.countUsableAttendancesPerUsers();
+        return CoffeeStatsResponse.from(userCoffeeStats);
+    }
+
     @Transactional
     public void disableUsedTardy(final Long meetingId) {
-        final Meeting meeting = meetingRepository.findById(meetingId)
-                .orElseThrow(MeetingNotFoundException::new);
-        final List<Participant> participants = meeting.getParticipants();
-        final List<Long> participantIds = participants.stream()
-                .map(Participant::getId)
-                .collect(Collectors.toList());
-        final List<Attendance> attendances = attendanceRepository.findByParticipantIdIn(participantIds);
-        final MeetingAttendances meetingAttendances = new MeetingAttendances(attendances, participants.size());
+        final MeetingAttendances meetingAttendances = findMeetingAttendancesBy(meetingId);
         validateEnoughTardyCountToDisable(meetingAttendances);
-        meetingAttendances.disableAttendances(participants.size());
+        meetingAttendances.disableAttendances();
     }
 
     private void validateAttendanceTime(final Meeting meeting) {
@@ -95,6 +97,17 @@ public class AttendanceService {
         if (serverTimeManager.isOverClosingTime(entranceTime)) {
             throw new ClosingTimeExcessException();
         }
+    }
+
+    private MeetingAttendances findMeetingAttendancesBy(final Long meetingId) {
+        final Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(MeetingNotFoundException::new);
+        final List<Participant> participants = meeting.getParticipants();
+        final List<Long> participantIds = participants.stream()
+                .map(Participant::getId)
+                .collect(Collectors.toList());
+        final List<Attendance> attendances = attendanceRepository.findByParticipantIdIn(participantIds);
+        return new MeetingAttendances(attendances, participants.size());
     }
 
     private void validateEnoughTardyCountToDisable(final MeetingAttendances attendances) {

--- a/backend/src/main/java/com/woowacourse/moragora/service/AttendanceService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/AttendanceService.java
@@ -24,7 +24,6 @@ import com.woowacourse.moragora.support.ServerTimeManager;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -102,12 +101,9 @@ public class AttendanceService {
     private MeetingAttendances findMeetingAttendancesBy(final Long meetingId) {
         final Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(MeetingNotFoundException::new);
-        final List<Participant> participants = meeting.getParticipants();
-        final List<Long> participantIds = participants.stream()
-                .map(Participant::getId)
-                .collect(Collectors.toList());
+        final List<Long> participantIds = meeting.getParticipantIds();
         final List<Attendance> attendances = attendanceRepository.findByParticipantIdIn(participantIds);
-        return new MeetingAttendances(attendances, participants.size());
+        return new MeetingAttendances(attendances, participantIds.size());
     }
 
     private void validateEnoughTardyCountToDisable(final MeetingAttendances attendances) {

--- a/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
@@ -70,7 +70,7 @@ public class MeetingService {
 
         saveParticipants(meeting, loginUser, users);
 
-        request.getStartDate().datesUntil(request.getEndDate())
+        request.getStartDate().datesUntil(request.getEndDate().plusDays(1))
                 .map(date -> new Event(date, request.getEntranceTime(), request.getLeaveTime(), meeting))
                 .forEach(eventRepository::save);
 

--- a/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
@@ -85,7 +85,7 @@ public class MeetingService {
 
         putAttendanceIfAbsent(meeting, participants);
 
-        final MeetingAttendances meetingAttendances = findAttendancesByMeeting(participants);
+        final MeetingAttendances meetingAttendances = findAttendancesByMeeting(meeting.getParticipantIds());
         final LocalDate today = serverTimeManager.getDate();
         final Event event = eventRepository.findByMeetingIdAndDate(meeting.getId(), today)
                 .orElseThrow(EventNotFoundException::new);
@@ -117,8 +117,8 @@ public class MeetingService {
 
     private MeetingAttendances getMeetingAttendances(final Participant participant) {
         final Meeting meeting = participant.getMeeting();
-        final List<Participant> participants = meeting.getParticipants();
-        return findAttendancesByMeeting(participants);
+        final List<Long> participantIds = meeting.getParticipantIds();
+        return findAttendancesByMeeting(participantIds);
     }
 
     /**
@@ -177,12 +177,9 @@ public class MeetingService {
         }
     }
 
-    private MeetingAttendances findAttendancesByMeeting(final List<Participant> participants) {
-        final List<Long> participantIds = participants.stream()
-                .map(Participant::getId)
-                .collect(Collectors.toList());
+    private MeetingAttendances findAttendancesByMeeting(final List<Long> participantIds) {
         final List<Attendance> foundAttendances = attendanceRepository.findByParticipantIdIn(participantIds);
-        return new MeetingAttendances(foundAttendances, participants.size());
+        return new MeetingAttendances(foundAttendances, participantIds.size());
     }
 
     private ParticipantResponse generateParticipantResponse(final LocalDateTime now,

--- a/backend/src/test/java/com/woowacourse/moragora/controller/AttendanceControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/AttendanceControllerTest.java
@@ -98,10 +98,10 @@ class AttendanceControllerTest extends ControllerTest {
         final Long meetingId = 1L;
         final CoffeeStatsResponse coffeeStatsResponse = new CoffeeStatsResponse(
                 List.of(
-                        new CoffeeStatResponse(1L, "썬", 3),
-                        new CoffeeStatResponse(3L, "필즈", 2),
-                        new CoffeeStatResponse(5L, "포키", 1),
-                        new CoffeeStatResponse(6L, "쿤", 1)
+                        new CoffeeStatResponse(1L, "썬", 3L),
+                        new CoffeeStatResponse(3L, "필즈", 2L),
+                        new CoffeeStatResponse(5L, "포키", 1L),
+                        new CoffeeStatResponse(6L, "쿤", 1L)
                 )
         );
         given(attendanceService.countUsableCoffeeStack(any(Long.class)))

--- a/backend/src/test/java/com/woowacourse/moragora/controller/AttendanceControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/AttendanceControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -115,7 +116,16 @@ class AttendanceControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.userCoffeeStats[?(@.id=='3')].coffeeCount", contains(2)))
                 .andExpect(jsonPath("$.userCoffeeStats[?(@.id=='5')].coffeeCount", contains(1)))
                 .andExpect(jsonPath("$.userCoffeeStats[?(@.id=='6')].coffeeCount", contains(1)))
-        ;
+                .andDo(document("meeting/usable-coffee",
+                        responseFields(
+                                fieldWithPath("userCoffeeStats[].id").type(JsonFieldType.NUMBER)
+                                        .description(1L),
+                                fieldWithPath("userCoffeeStats[].nickname").type(JsonFieldType.STRING)
+                                        .description("아스피"),
+                                fieldWithPath("userCoffeeStats[].coffeeCount").type(JsonFieldType.NUMBER)
+                                        .description("3")
+                        )
+                ));
     }
 
     @DisplayName("모임의 커피스택을 비운다.")
@@ -132,6 +142,7 @@ class AttendanceControllerTest extends ControllerTest {
         final ResultActions resultActions = performPost("/meetings/" + meetingId + "/coffees/use");
 
         // then
-        resultActions.andExpect(status().isNoContent());
+        resultActions.andExpect(status().isNoContent())
+                .andDo(document("meeting/use-coffee"));
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/entity/MeetingAttendancesTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/entity/MeetingAttendancesTest.java
@@ -74,12 +74,12 @@ class MeetingAttendancesTest {
         final Participant participant2 = new Participant(user2, meeting, false);
         final Participant participant3 = new Participant(user3, meeting, false);
 
-        final Attendance attendance1 = new Attendance(1L, Status.TARDY, false, participant1, event1);
-        final Attendance attendance2 = new Attendance(2L, Status.TARDY, false, participant2, event1);
-        final Attendance attendance3 = new Attendance(3L, Status.PRESENT, false, participant3, event1);
-        final Attendance attendance4 = new Attendance(4L, Status.TARDY, false, participant1, event2);
-        final Attendance attendance5 = new Attendance(5L, Status.PRESENT, false, participant2, event2);
-        final Attendance attendance6 = new Attendance(6L, Status.PRESENT, false, participant3, event2);
+        final Attendance attendance1 = new Attendance(Status.TARDY, false, participant1, event1);
+        final Attendance attendance2 = new Attendance(Status.TARDY, false, participant2, event1);
+        final Attendance attendance3 = new Attendance(Status.PRESENT, false, participant3, event1);
+        final Attendance attendance4 = new Attendance(Status.TARDY, false, participant1, event2);
+        final Attendance attendance5 = new Attendance(Status.PRESENT, false, participant2, event2);
+        final Attendance attendance6 = new Attendance(Status.PRESENT, false, participant3, event2);
 
         final List<Attendance> attendances = List.of(
                 attendance1, attendance2, attendance3, attendance4, attendance5, attendance6);
@@ -114,12 +114,12 @@ class MeetingAttendancesTest {
         final Participant participant2 = new Participant(user2, meeting, false);
         final Participant participant3 = new Participant(user3, meeting, false);
 
-        final Attendance attendance1 = new Attendance(1L, Status.TARDY, false, participant1, event1);
-        final Attendance attendance2 = new Attendance(2L, Status.TARDY, false, participant2, event1);
-        final Attendance attendance3 = new Attendance(3L, Status.TARDY, false, participant3, event1);
-        final Attendance attendance4 = new Attendance(4L, Status.TARDY, false, participant1, event2);
-        final Attendance attendance5 = new Attendance(5L, Status.TARDY, false, participant2, event2);
-        final Attendance attendance6 = new Attendance(6L, Status.TARDY, false, participant3, event2);
+        final Attendance attendance1 = new Attendance(Status.TARDY, false, participant1, event1);
+        final Attendance attendance2 = new Attendance(Status.TARDY, false, participant2, event1);
+        final Attendance attendance3 = new Attendance(Status.TARDY, false, participant3, event1);
+        final Attendance attendance4 = new Attendance(Status.TARDY, false, participant1, event2);
+        final Attendance attendance5 = new Attendance(Status.TARDY, false, participant2, event2);
+        final Attendance attendance6 = new Attendance(Status.TARDY, false, participant3, event2);
 
         final List<Attendance> attendances = List.of(
                 attendance1, attendance2, attendance3, attendance4, attendance5, attendance6);

--- a/backend/src/test/java/com/woowacourse/moragora/entity/MeetingAttendancesTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/entity/MeetingAttendancesTest.java
@@ -8,10 +8,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class MeetingAttendancesTest {
 
@@ -52,36 +53,82 @@ class MeetingAttendancesTest {
         assertThat(actual).isEqualTo(expected);
     }
 
-    @DisplayName("비활성화할 개수만큼 출석부의 데이터를 비활성화한다.")
-    @ParameterizedTest
-    @ValueSource(ints = {1, 2, 3})
-    void disableAttendances(final int sizeToDisable) {
+    @DisplayName("커피스택으로 사용할 수 있는 유저별 출석부 데이터 개수를 센다.")
+    @Test
+    void countUsableAttendancesPerUsers() {
         // given
         final EncodedPassword encodedPassword = EncodedPassword.fromRawValue("qwer1234!");
-        final LocalDateTime now = LocalDateTime.now();
-        final LocalDate date = now.toLocalDate();
-        final LocalTime time = now.toLocalTime();
-        final User user1 = new User("sun@gmail.com", encodedPassword, "sun");
-        final User user2 = new User("kun@gmail.com", encodedPassword, "kun");
-        final User user3 = new User("forki@gmail.com", encodedPassword, "forki");
-        final Meeting meeting = new Meeting("미팅1", date, date);
+        final User user1 = new User(1L, "sun@gmail.com", encodedPassword, "sun");
+        final User user2 = new User(2L, "kun@gmail.com", encodedPassword, "kun");
+        final User user3 = new User(3L, "forky@gmail.com", encodedPassword, "forky");
 
-        final Event event = new Event(date, time, time, meeting);
+        final LocalDateTime now = LocalDateTime.now();
+        final LocalDate endDate = now.toLocalDate();
+        final LocalDate startDate = endDate.minusDays(1);
+        final LocalTime time = now.toLocalTime();
+
+        final Meeting meeting = new Meeting("미팅1", startDate, endDate);
+        final Event event1 = new Event(startDate, time, time, meeting);
+        final Event event2 = new Event(endDate, time, time, meeting);
         final Participant participant1 = new Participant(user1, meeting, true);
         final Participant participant2 = new Participant(user2, meeting, false);
         final Participant participant3 = new Participant(user3, meeting, false);
 
-        final Attendance attendance1 = new Attendance(1L, Status.TARDY, false, participant1, event);
-        final Attendance attendance2 = new Attendance(2L, Status.TARDY, false, participant2, event);
-        final Attendance attendance3 = new Attendance(3L, Status.TARDY, false, participant3, event);
+        final Attendance attendance1 = new Attendance(1L, Status.TARDY, false, participant1, event1);
+        final Attendance attendance2 = new Attendance(2L, Status.TARDY, false, participant2, event1);
+        final Attendance attendance3 = new Attendance(3L, Status.PRESENT, false, participant3, event1);
+        final Attendance attendance4 = new Attendance(4L, Status.TARDY, false, participant1, event2);
+        final Attendance attendance5 = new Attendance(5L, Status.PRESENT, false, participant2, event2);
+        final Attendance attendance6 = new Attendance(6L, Status.PRESENT, false, participant3, event2);
 
-        final List<Attendance> attendances = List.of(attendance1, attendance2, attendance3);
+        final List<Attendance> attendances = List.of(
+                attendance1, attendance2, attendance3, attendance4, attendance5, attendance6);
+        final MeetingAttendances meetingAttendances = new MeetingAttendances(attendances, 3);
+
+        final Map<User, Long> expected = Map.of(user1, 2L, user2, 1L);
+        // when
+        final Map<User, Long> actual = meetingAttendances.countUsableAttendancesPerUsers();
+
+        // then
+        assertThat(actual).containsExactlyInAnyOrderEntriesOf(expected);
+    }
+
+    @DisplayName("참가자의 수 만큼 출석부의 데이터를 비활성화한다.")
+    @Test
+    void disableAttendances() {
+        // given
+        final EncodedPassword encodedPassword = EncodedPassword.fromRawValue("qwer1234!");
+        final User user1 = new User("sun@gmail.com", encodedPassword, "sun");
+        final User user2 = new User("kun@gmail.com", encodedPassword, "kun");
+        final User user3 = new User("forky@gmail.com", encodedPassword, "forky");
+
+        final LocalDateTime now = LocalDateTime.now();
+        final LocalDate endDate = now.toLocalDate();
+        final LocalDate startDate = endDate.minusDays(1);
+        final LocalTime time = now.toLocalTime();
+        final Meeting meeting = new Meeting("미팅1", startDate, endDate);
+        final Event event1 = new Event(startDate, time, time, meeting);
+        final Event event2 = new Event(endDate, time, time, meeting);
+
+        final Participant participant1 = new Participant(user1, meeting, true);
+        final Participant participant2 = new Participant(user2, meeting, false);
+        final Participant participant3 = new Participant(user3, meeting, false);
+
+        final Attendance attendance1 = new Attendance(1L, Status.TARDY, false, participant1, event1);
+        final Attendance attendance2 = new Attendance(2L, Status.TARDY, false, participant2, event1);
+        final Attendance attendance3 = new Attendance(3L, Status.TARDY, false, participant3, event1);
+        final Attendance attendance4 = new Attendance(4L, Status.TARDY, false, participant1, event2);
+        final Attendance attendance5 = new Attendance(5L, Status.TARDY, false, participant2, event2);
+        final Attendance attendance6 = new Attendance(6L, Status.TARDY, false, participant3, event2);
+
+        final List<Attendance> attendances = List.of(
+                attendance1, attendance2, attendance3, attendance4, attendance5, attendance6);
         final MeetingAttendances meetingAttendances = new MeetingAttendances(attendances, 3);
 
         // when
-        meetingAttendances.disableAttendances(sizeToDisable);
+        meetingAttendances.disableAttendances();
 
         // then
-        assertThat(meetingAttendances.countTardy()).isEqualTo(attendances.size() - sizeToDisable);
+        assertThat(meetingAttendances.countTardy()).isEqualTo(3);
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/service/AttendanceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/AttendanceServiceTest.java
@@ -115,11 +115,11 @@ class AttendanceServiceTest {
         assertThat(response).usingRecursiveComparison()
                 .isEqualTo(new CoffeeStatsResponse(
                         List.of(
-                                new CoffeeStatResponse(1L, "아스피", 1),
-                                new CoffeeStatResponse(2L, "필즈", 3),
-                                new CoffeeStatResponse(3L, "포키", 1),
-                                new CoffeeStatResponse(4L, "썬", 1),
-                                new CoffeeStatResponse(5L, "우디", 1)
+                                new CoffeeStatResponse(1L, "아스피", 1L),
+                                new CoffeeStatResponse(2L, "필즈", 3L),
+                                new CoffeeStatResponse(3L, "포키", 1L),
+                                new CoffeeStatResponse(4L, "썬", 1L),
+                                new CoffeeStatResponse(5L, "우디", 1L)
                         ))
                 );
     }

--- a/backend/src/test/java/com/woowacourse/moragora/service/AttendanceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/AttendanceServiceTest.java
@@ -100,38 +100,37 @@ class AttendanceServiceTest {
     void countUsableCoffeeStack() {
         // given
         // 모임 생성
-        final LocalDate endDate = LocalDate.now();
-        final LocalDate startDate = endDate.minusDays(1);
-        final LocalTime now = LocalTime.now();
-        final MeetingRequest meetingRequest = new MeetingRequest("meeting",
-                startDate,
-                endDate,
-                now,
-                now,
-                List.of(2L, 3L)
-        );
-        final Long meetingId = meetingService.save(meetingRequest, 1L);
+//        final LocalDate endDate = LocalDate.now();
+//        final LocalDate startDate = endDate.minusDays(1);
+//        final LocalTime now = LocalTime.now();
+//        final MeetingRequest meetingRequest = new MeetingRequest("meeting",
+//                startDate,
+//                endDate,
+//                now,
+//                now,
+//                List.of(2L, 3L)
+//        );
+        final Long meetingId = 1L;
 
         // 출석부 데이터 생성
         final UserAttendanceRequest userAttendanceRequest = new UserAttendanceRequest(Status.PRESENT);
-        serverTimeManager.refresh(startDate.atTime(now));
-        meetingService.findById(meetingId, 1L);
-        attendanceService.updateAttendance(meetingId, 1L, userAttendanceRequest);
-        attendanceService.updateAttendance(meetingId, 2L, userAttendanceRequest);
-
-        serverTimeManager.refresh(endDate.atTime(now));
+        serverTimeManager.refresh(LocalDateTime.of(2022, 7, 15, 10, 00));
         meetingService.findById(meetingId, 1L);
         attendanceService.updateAttendance(meetingId, 1L, userAttendanceRequest);
 
         // when
+        serverTimeManager.refresh(LocalDateTime.of(2022, 7, 15, 10, 06));
         final CoffeeStatsResponse response = attendanceService.countUsableCoffeeStack(meetingId);
 
         // then
         assertThat(response).usingRecursiveComparison()
                 .isEqualTo(new CoffeeStatsResponse(
                         List.of(
-                                new CoffeeStatResponse(2L, "필즈", 1),
-                                new CoffeeStatResponse(3L, "포키", 2)
+                                new CoffeeStatResponse(1L, "아스피", 1),
+                                new CoffeeStatResponse(2L, "필즈", 3),
+                                new CoffeeStatResponse(3L, "포키", 1),
+                                new CoffeeStatResponse(4L, "썬", 1),
+                                new CoffeeStatResponse(5L, "우디", 1)
                         ))
                 );
     }

--- a/backend/src/test/java/com/woowacourse/moragora/service/AttendanceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/AttendanceServiceTest.java
@@ -99,27 +99,16 @@ class AttendanceServiceTest {
     @Test
     void countUsableCoffeeStack() {
         // given
-        // 모임 생성
-//        final LocalDate endDate = LocalDate.now();
-//        final LocalDate startDate = endDate.minusDays(1);
-//        final LocalTime now = LocalTime.now();
-//        final MeetingRequest meetingRequest = new MeetingRequest("meeting",
-//                startDate,
-//                endDate,
-//                now,
-//                now,
-//                List.of(2L, 3L)
-//        );
         final Long meetingId = 1L;
 
         // 출석부 데이터 생성
         final UserAttendanceRequest userAttendanceRequest = new UserAttendanceRequest(Status.PRESENT);
-        serverTimeManager.refresh(LocalDateTime.of(2022, 7, 15, 10, 00));
+        serverTimeManager.refresh(LocalDateTime.of(2022, 7, 15, 10, 0));
         meetingService.findById(meetingId, 1L);
         attendanceService.updateAttendance(meetingId, 1L, userAttendanceRequest);
 
         // when
-        serverTimeManager.refresh(LocalDateTime.of(2022, 7, 15, 10, 06));
+        serverTimeManager.refresh(LocalDateTime.of(2022, 7, 15, 10, 6));
         final CoffeeStatsResponse response = attendanceService.countUsableCoffeeStack(meetingId);
 
         // then


### PR DESCRIPTION
<!--Close #issue_number를 작성한다.-->
Close #246 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/show-coffee-use -> dev

## 요구사항
<!--로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
- 커피 비우기 전 소비할 내역 조회
- 누가 커피를 몇 잔 사야하는지 반환

## 변경사항
- 커피 스택을 비울 때 비울 개수를 parameter로 받지 않고 내부 필드 `numberOfParticipants`로 결정합니다

## [Optional] 논의하고 싶은 내용

