### PR TITLE
[BE] 출석부 생성 시간 입장 시간 1분 전으로 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/moragora/service/EventService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/EventService.java
@@ -28,7 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class EventService {
 
-    private static final int SCHEDULING_SUBTRACT_TIME = 30;
+    private static final int SCHEDULING_SUBTRACT_TIME = 1;
 
     private final Map<Event, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
     private final TaskScheduler taskScheduler;


### PR DESCRIPTION
Close #270 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/scheduling -> dev

## 요구사항
- 스케줄링이 모임 시작 1 분전에 생성되는 것으로 변경한다.

## 변경사항

## [Optional] 논의하고 싶은 내용

