### PR TITLE
[FE] 모든 경로에 대해 history API fallback 설정 

### DIFF
--- a/frontend/webpack/webpack.common.js
+++ b/frontend/webpack/webpack.common.js
@@ -12,6 +12,7 @@ module.exports = {
   entry: join(__dirname, '../src/index.tsx'),
   devtool: 'eval-source-map',
   output: {
+    publicPath: '/',
     path: resolve(__dirname, '../build'),
     filename: '[name].bundle.js',
     assetModuleFilename: 'images/[hash][ext][query]',


### PR DESCRIPTION
Close #206 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/fe/history-api-fallback -> dev

## 요구사항
- [x] 모든 경로를 루트 경로로 리다이렉션한다.

## 변경사항
- webpack config에 publicPath 추가

## [Optional] 논의하고 싶은 내용

