### PR TITLE
[BE] 출석부 조회 기능 구현

### DIFF
--- a/backend/src/docs/asciidoc/attendance.asciidoc
+++ b/backend/src/docs/asciidoc/attendance.asciidoc
@@ -1,0 +1,28 @@
+= Attendance
+:toc: left
+:toclevels: 2
+:sectlinks:
+:source-highlighter: highlightjs
+
+[[home]]
+== home
+
+* link:index.html[홈으로 가기]
+
+[[show]]
+== 출석부 조회
+
+[[show]]
+=== HTTP request
+
+include::{snippets}/attendance/show/http-request.adoc[]
+
+=== HTTP response
+
+include::{snippets}/attendance/show/http-response.adoc[]
+
+=== Response fields
+
+include::{snippets}/attendance/show/response-fields.adoc[]
+
+

--- a/backend/src/docs/asciidoc/index.asciidoc
+++ b/backend/src/docs/asciidoc/index.asciidoc
@@ -9,6 +9,7 @@
 * link:auth.html[Auth]
 * link:user.html[User]
 * link:meeting.html[Meeting]
+* link:attendance.html[Attendance]
 * link:common.html[Common]
 
 [[overview]]

--- a/backend/src/main/java/com/woowacourse/moragora/controller/AttendanceController.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/AttendanceController.java
@@ -3,6 +3,7 @@ package com.woowacourse.moragora.controller;
 import com.woowacourse.auth.support.Authentication;
 import com.woowacourse.auth.support.AuthenticationPrincipal;
 import com.woowacourse.auth.support.MasterAuthorization;
+import com.woowacourse.moragora.dto.AttendancesResponse;
 import com.woowacourse.moragora.dto.CoffeeStatsResponse;
 import com.woowacourse.moragora.dto.UserAttendanceRequest;
 import com.woowacourse.moragora.service.AttendanceService;
@@ -12,10 +13,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Authentication
+@RequestMapping("/meetings/{meetingId}")
 public class AttendanceController {
 
     private final AttendanceService attendanceService;
@@ -24,8 +27,15 @@ public class AttendanceController {
         this.attendanceService = attendanceService;
     }
 
+    @Authentication
+    @GetMapping("/attendances/today")
+    public ResponseEntity<AttendancesResponse> showAttendances(@PathVariable final Long meetingId) {
+        final AttendancesResponse attendancesResponse = attendanceService.findTodayAttendancesByMeeting(meetingId);
+        return ResponseEntity.ok(attendancesResponse);
+    }
+
     @MasterAuthorization
-    @PutMapping("/meetings/{meetingId}/users/{userId}")
+    @PutMapping("/users/{userId}")
     public ResponseEntity<Void> markAttendance(@PathVariable final Long meetingId,
                                                @PathVariable final Long userId,
                                                @RequestBody final UserAttendanceRequest request,
@@ -34,14 +44,14 @@ public class AttendanceController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/meetings/{meetingId}/coffees/use")
+    @GetMapping("/coffees/use")
     public ResponseEntity<CoffeeStatsResponse> showUserCoffeeStats(@PathVariable final Long meetingId) {
         final CoffeeStatsResponse response = attendanceService.countUsableCoffeeStack(meetingId);
         return ResponseEntity.ok(response);
     }
 
     @MasterAuthorization
-    @PostMapping("/meetings/{meetingId}/coffees/use")
+    @PostMapping("/coffees/use")
     public ResponseEntity<Void> useCoffeeStack(@PathVariable final Long meetingId,
                                                @AuthenticationPrincipal final Long loginId) {
         attendanceService.disableUsedTardy(meetingId);

--- a/backend/src/main/java/com/woowacourse/moragora/controller/EventController.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/EventController.java
@@ -4,9 +4,7 @@ import com.woowacourse.auth.support.Authentication;
 import com.woowacourse.auth.support.AuthenticationPrincipal;
 import com.woowacourse.auth.support.MasterAuthorization;
 import com.woowacourse.moragora.dto.EventsRequest;
-import com.woowacourse.moragora.entity.Event;
 import com.woowacourse.moragora.service.EventService;
-import java.util.List;
 import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,8 +27,7 @@ public class EventController {
     public ResponseEntity<Void> add(@RequestBody @Valid final EventsRequest request,
                                     @PathVariable final Long meetingId,
                                     @AuthenticationPrincipal final Long loginId) {
-        final List<Event> savedEvent = eventService.save(request, meetingId);
-        eventService.saveSchedules(savedEvent);
+        eventService.save(request, meetingId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/AttendanceResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/AttendanceResponse.java
@@ -1,0 +1,28 @@
+package com.woowacourse.moragora.dto;
+
+import com.woowacourse.moragora.entity.Attendance;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class AttendanceResponse {
+
+    private final Long id;
+    private final String nickname;
+    private final String attendanceStatus;
+
+    public AttendanceResponse(final Long id, final String nickname, final String attendanceStatus) {
+        this.id = id;
+        this.nickname = nickname;
+        this.attendanceStatus = attendanceStatus;
+    }
+
+    public static AttendanceResponse from(final Attendance attendance) {
+        return new AttendanceResponse(
+                attendance.getParticipant().getUser().getId(),
+                attendance.getParticipant().getUser().getNickname(),
+                attendance.getStatus().name()
+        );
+    }
+}

--- a/backend/src/main/java/com/woowacourse/moragora/dto/AttendancesResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/AttendancesResponse.java
@@ -1,0 +1,16 @@
+package com.woowacourse.moragora.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class AttendancesResponse {
+
+    private final List<AttendanceResponse> users;
+
+    public AttendancesResponse(final List<AttendanceResponse> users) {
+        this.users = users;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/moragora/dto/ParticipantResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/ParticipantResponse.java
@@ -2,7 +2,6 @@ package com.woowacourse.moragora.dto;
 
 import com.woowacourse.moragora.entity.Status;
 import com.woowacourse.moragora.entity.user.User;
-import java.util.Locale;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -24,16 +23,8 @@ public class ParticipantResponse {
         this.id = id;
         this.email = email;
         this.nickname = nickname;
-        this.attendanceStatus = attendanceStatus.toLowerCase(Locale.ROOT);
+        this.attendanceStatus = attendanceStatus.toLowerCase();
         this.tardyCount = tardyCount;
-    }
-
-    public ParticipantResponse(final Long id,
-                               final String email,
-                               final String nickname,
-                               final Status attendanceStatus,
-                               final int tardyCount) {
-        this(id, email, nickname, attendanceStatus.name(), tardyCount);
     }
 
     public static ParticipantResponse of(final User foundUser, final Status attendanceStatus, final int tardyCount) {
@@ -41,7 +32,7 @@ public class ParticipantResponse {
                 foundUser.getId(),
                 foundUser.getEmail(),
                 foundUser.getNickname(),
-                attendanceStatus,
+                attendanceStatus.name(),
                 tardyCount);
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/entity/Status.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/Status.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 
 public enum Status {
 
-    PRESENT, TARDY;
+    PRESENT, TARDY, NONE;
 
     @JsonCreator
     public static Status fromEnum(final String value) {

--- a/backend/src/main/java/com/woowacourse/moragora/service/EventService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/EventService.java
@@ -6,15 +6,11 @@ import com.woowacourse.moragora.entity.Event;
 import com.woowacourse.moragora.entity.Meeting;
 import com.woowacourse.moragora.entity.Participant;
 import com.woowacourse.moragora.entity.Status;
-import com.woowacourse.moragora.exception.event.EventNotFoundException;
 import com.woowacourse.moragora.exception.meeting.MeetingNotFoundException;
 import com.woowacourse.moragora.repository.AttendanceRepository;
 import com.woowacourse.moragora.repository.EventRepository;
 import com.woowacourse.moragora.repository.MeetingRepository;
-import java.sql.Date;
-import java.time.Instant;
-import java.time.LocalTime;
-import java.time.ZoneId;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -47,37 +43,26 @@ public class EventService {
     }
 
     @Transactional
-    public List<Event> save(final EventsRequest request, final Long meetingId) {
+    public void save(final EventsRequest request, final Long meetingId) {
         final Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(MeetingNotFoundException::new);
         final List<Event> events = request.toEntities(meeting);
-        return eventRepository.saveAll(events);
+        eventRepository.saveAll(events);
+        saveAllAttendances(meeting.getParticipants(), events);
     }
 
-    @Transactional
-    public void saveSchedules(final List<Event> events) {
-        events.forEach(event -> {
-            ScheduledFuture<?> task = taskScheduler.schedule(
-                    () -> saveAttendances(event), Date.from(getInstant(event)));
-            scheduledTasks.put(event, task);
-        });
-    }
-
-    @Transactional
-    public void saveAttendances(final Event event) {
-        final Event foundEvent = eventRepository.findById(event.getId())
-                .orElseThrow(EventNotFoundException::new);
-        final Meeting meeting = foundEvent.getMeeting();
-        final List<Participant> participants = meeting.getParticipants();
-        final List<Attendance> attendances = participants.stream()
-                .map(participant -> new Attendance(Status.TARDY, false, participant, foundEvent))
+    private void saveAllAttendances(final List<Participant> participants, final List<Event> events) {
+        final List<Attendance> attendances = events.stream()
+                .map(event -> createAttendances(participants, event))
+                .flatMap(Collection::stream)
                 .collect(Collectors.toList());
+
         attendanceRepository.saveAll(attendances);
     }
 
-    private Instant getInstant(final Event event) {
-        final LocalTime localTime = event.getEntranceTime().minusMinutes(SCHEDULING_SUBTRACT_TIME);
-        return localTime.atDate(event.getDate()).
-                atZone(ZoneId.systemDefault()).toInstant();
+    private List<Attendance> createAttendances(List<Participant> participants, Event event) {
+        return participants.stream()
+                .map(participant -> new Attendance(Status.NONE, false, participant, event))
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/AttendanceAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/AttendanceAcceptanceTest.java
@@ -1,33 +1,53 @@
-//package com.woowacourse.moragora.acceptance;
-//
-//import static com.woowacourse.moragora.support.MeetingFixtures.MORAGORA;
-//import static com.woowacourse.moragora.support.UserFixtures.MASTER;
-//import static com.woowacourse.moragora.support.UserFixtures.NO_MASTER;
-//import static com.woowacourse.moragora.support.UserFixtures.createUsers;
-//import static org.hamcrest.Matchers.equalTo;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.BDDMockito.given;
-//
-//import com.woowacourse.moragora.dto.UserAttendanceRequest;
-//import com.woowacourse.moragora.entity.Status;
-//import com.woowacourse.moragora.entity.user.User;
-//import com.woowacourse.moragora.support.ServerTimeManager;
-//import io.restassured.RestAssured;
-//import io.restassured.response.ValidatableResponse;
-//import java.time.LocalDateTime;
-//import java.time.LocalTime;
-//import java.util.List;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.boot.test.mock.mockito.MockBean;
-//import org.springframework.http.HttpStatus;
-//import org.springframework.http.MediaType;
-//
-//class AttendanceAcceptanceTest extends AcceptanceTest {
-//
-//    @MockBean
-//    private ServerTimeManager serverTimeManager;
-//
+package com.woowacourse.moragora.acceptance;
+
+import static com.woowacourse.moragora.support.EventFixtures.EVENT1;
+import static com.woowacourse.moragora.support.MeetingFixtures.MORAGORA;
+import static com.woowacourse.moragora.support.UserFixtures.FORKY;
+import static com.woowacourse.moragora.support.UserFixtures.KUN;
+import static com.woowacourse.moragora.support.UserFixtures.SUN;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.BDDMockito.given;
+
+import com.woowacourse.moragora.entity.Meeting;
+import com.woowacourse.moragora.entity.user.User;
+import com.woowacourse.moragora.support.ServerTimeManager;
+import io.restassured.response.ValidatableResponse;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+
+class AttendanceAcceptanceTest extends AcceptanceTest {
+
+    @MockBean
+    private ServerTimeManager serverTimeManager;
+
+    @DisplayName("오늘의 출석부를 요청하면 날짜에 해당하는 출석부와 상태코드 200을 반환한다.")
+    @Test
+    void showAttendance() {
+        // given
+        final User user1 = SUN.create();
+        final User user2 = KUN.create();
+        final User user3 = FORKY.create();
+        final List<Long> userIds = saveUsers(List.of(user2, user3));
+        final String token = signUpAndGetToken(user1);
+        final Meeting meeting = MORAGORA.create();
+        final Long meetingId = (long) saveMeeting(token, userIds, meeting);
+
+        saveEvents(token, List.of(EVENT1.create(meeting)), meetingId);
+        given(serverTimeManager.getDate())
+                .willReturn(EVENT1.getDate());
+
+        // when
+        final ValidatableResponse response = get("/meetings/" + meetingId + "/attendances/today", token);
+
+        // then
+        response.statusCode(HttpStatus.OK.value())
+                .body("users.nickname", containsInAnyOrder(SUN.getNickname(), KUN.getNickname(), FORKY.getNickname()))
+                .body("users.attendanceStatus", containsInAnyOrder("NONE", "NONE", "NONE"));
+    }
+
 //    @DisplayName("미팅 참가자의 출석을 업데이트하면 상태코드 204을 반환한다.")
 //    @Test
 //    void updateAttendance() {
@@ -148,4 +168,4 @@
 //        // then
 //        response.statusCode(HttpStatus.FORBIDDEN.value());
 //    }
-//}
+}

--- a/backend/src/test/java/com/woowacourse/moragora/controller/AttendanceControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/AttendanceControllerTest.java
@@ -18,11 +18,13 @@ import com.woowacourse.moragora.dto.CoffeeStatResponse;
 import com.woowacourse.moragora.dto.CoffeeStatsResponse;
 import com.woowacourse.moragora.dto.UserAttendanceRequest;
 import com.woowacourse.moragora.entity.Status;
+import com.woowacourse.moragora.exception.ClientRuntimeException;
 import com.woowacourse.moragora.exception.meeting.MeetingNotFoundException;
 import com.woowacourse.moragora.exception.participant.ParticipantNotFoundException;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -157,9 +159,9 @@ class AttendanceControllerTest extends ControllerTest {
         validateToken(String.valueOf(userId));
         final AttendancesResponse attendancesResponse = new AttendancesResponse(
                 List.of(
-                        new AttendanceResponse(1L, "썬", "NONE"),
-                        new AttendanceResponse(3L, "필즈", "NONE"),
-                        new AttendanceResponse(5L, "포키", "PRESENT")
+                        new AttendanceResponse(1L, "썬", "none"),
+                        new AttendanceResponse(3L, "필즈", "none"),
+                        new AttendanceResponse(5L, "포키", "present")
                 )
         );
         given(attendanceService.findTodayAttendancesByMeeting(any(Long.class)))
@@ -169,14 +171,37 @@ class AttendanceControllerTest extends ControllerTest {
 
         // then
         resultActions.andExpect(status().isOk())
-                .andDo(document("meeting/show-attendances",
+                .andDo(document("attendance/show",
                         responseFields(
                                 fieldWithPath("users[].id").type(JsonFieldType.NUMBER)
                                         .description(1L),
                                 fieldWithPath("users[].nickname").type(JsonFieldType.STRING)
-                                        .description("아스피"),
+                                        .description("썬"),
                                 fieldWithPath("users[].attendanceStatus").type(JsonFieldType.STRING)
-                                        .description("NONE")
+                                        .description("none")
+                        )));
+    }
+
+    @DisplayName("오늘의 이벤트가 존재하지 않을 때 출석부를 조회할 경우 예외가 발생한다.")
+    @Test
+    void showAttendances_throwsException_ifEventNotExists() throws Exception {
+        // given
+        final Long meetingId = 1L;
+        final Long userId = 1L;
+        validateToken(String.valueOf(userId));
+
+        given(attendanceService.findTodayAttendancesByMeeting(any(Long.class)))
+                .willThrow(new ClientRuntimeException("오늘의 일정이 존재하지 않아 출석부를 조회할 수 없습니다.", HttpStatus.BAD_REQUEST));
+
+        // when
+        final ResultActions resultActions = performGet("/meetings/" + meetingId + "/attendances/today");
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andDo(document("attendance/show-event-not-exists",
+                        responseFields(
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("오늘의 일정이 존재하지 않아 출석부를 조회할 수 없습니다.")
                         )));
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/controller/AttendanceControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/AttendanceControllerTest.java
@@ -12,6 +12,8 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.moragora.dto.AttendanceResponse;
+import com.woowacourse.moragora.dto.AttendancesResponse;
 import com.woowacourse.moragora.dto.CoffeeStatResponse;
 import com.woowacourse.moragora.dto.CoffeeStatsResponse;
 import com.woowacourse.moragora.dto.UserAttendanceRequest;
@@ -144,5 +146,37 @@ class AttendanceControllerTest extends ControllerTest {
         // then
         resultActions.andExpect(status().isNoContent())
                 .andDo(document("meeting/use-coffee"));
+    }
+
+    @DisplayName("출석부를 조회한다.")
+    @Test
+    void showAttendances() throws Exception {
+        // given
+        final Long meetingId = 1L;
+        final Long userId = 1L;
+        validateToken(String.valueOf(userId));
+        final AttendancesResponse attendancesResponse = new AttendancesResponse(
+                List.of(
+                        new AttendanceResponse(1L, "썬", "NONE"),
+                        new AttendanceResponse(3L, "필즈", "NONE"),
+                        new AttendanceResponse(5L, "포키", "PRESENT")
+                )
+        );
+        given(attendanceService.findTodayAttendancesByMeeting(any(Long.class)))
+                .willReturn(attendancesResponse);
+        // when
+        final ResultActions resultActions = performGet("/meetings/" + meetingId + "/attendances/today");
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(document("meeting/show-attendances",
+                        responseFields(
+                                fieldWithPath("users[].id").type(JsonFieldType.NUMBER)
+                                        .description(1L),
+                                fieldWithPath("users[].nickname").type(JsonFieldType.STRING)
+                                        .description("아스피"),
+                                fieldWithPath("users[].attendanceStatus").type(JsonFieldType.STRING)
+                                        .description("NONE")
+                        )));
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
@@ -22,12 +22,13 @@ import com.woowacourse.moragora.dto.MyMeetingsResponse;
 import com.woowacourse.moragora.dto.ParticipantResponse;
 import com.woowacourse.moragora.entity.Meeting;
 import com.woowacourse.moragora.entity.Status;
+import com.woowacourse.moragora.entity.user.EncodedPassword;
+import com.woowacourse.moragora.entity.user.User;
 import com.woowacourse.moragora.exception.meeting.IllegalEntranceLeaveTimeException;
 import com.woowacourse.moragora.exception.participant.InvalidParticipantException;
 import com.woowacourse.moragora.exception.user.UserNotFoundException;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -226,9 +227,12 @@ class MeetingControllerTest extends ControllerTest {
     @Test
     void findOne() throws Exception {
         // given
-        final List<ParticipantResponse> participantResponses = new ArrayList<>();
-        participantResponses.add(new ParticipantResponse(1L, "abc@naver.com", "foo", Status.TARDY, 5));
-        participantResponses.add(new ParticipantResponse(2L, "def@naver.com", "boo", Status.TARDY, 8));
+        final User user1 = new User(1L, "abc@naver.com", EncodedPassword.fromRawValue("qwer1234!"), "foo");
+        final User user2 = new User(2L, "def@naver.com", EncodedPassword.fromRawValue("qwer1234!"), "boo");
+        final List<ParticipantResponse> participantResponses = List.of(
+                ParticipantResponse.of(user1, Status.TARDY, 5),
+                ParticipantResponse.of(user2, Status.TARDY, 8)
+        );
 
         final long id = 1L;
         final String name = "모임1";

--- a/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
@@ -247,13 +247,11 @@ class MeetingServiceTest {
         final Attendance attendance3 = dataSupport.saveAttendance(participant3, event1, Status.TARDY);
 
         final List<ParticipantResponse> usersResponse = List.of(
-                new ParticipantResponse(user1.getId(), user1.getEmail(), user1.getNickname(),
-                        attendance1.getStatus(), 0),
-                new ParticipantResponse(user2.getId(), user2.getEmail(), user2.getNickname(),
-                        attendance2.getStatus(), 0),
-                new ParticipantResponse(user3.getId(), user3.getEmail(), user3.getNickname(),
-                        attendance3.getStatus(), 0)
+                ParticipantResponse.of(user1, attendance1.getStatus(), 0),
+                ParticipantResponse.of(user2, attendance2.getStatus(), 0),
+                ParticipantResponse.of(user3, attendance3.getStatus(), 0)
         );
+
         final MeetingResponse expectedMeetingResponse = MeetingResponse.builder()
                 .id(meeting.getId())
                 .name(meeting.getName())
@@ -295,13 +293,11 @@ class MeetingServiceTest {
         final Attendance attendance3 = dataSupport.saveAttendance(participant3, event1, Status.TARDY);
 
         final List<ParticipantResponse> usersResponse = List.of(
-                new ParticipantResponse(user1.getId(), user1.getEmail(), user1.getNickname(),
-                        attendance1.getStatus(), 1),
-                new ParticipantResponse(user2.getId(), user2.getEmail(), user2.getNickname(),
-                        attendance2.getStatus(), 1),
-                new ParticipantResponse(user3.getId(), user3.getEmail(), user3.getNickname(),
-                        attendance3.getStatus(), 1)
+                ParticipantResponse.of(user1, attendance1.getStatus(), 1),
+                ParticipantResponse.of(user2, attendance2.getStatus(), 1),
+                ParticipantResponse.of(user3, attendance3.getStatus(), 1)
         );
+
         final MeetingResponse expectedMeetingResponse = MeetingResponse.builder()
                 .id(meeting.getId())
                 .name(meeting.getName())

--- a/backend/src/test/java/com/woowacourse/moragora/support/EventFixtures.java
+++ b/backend/src/test/java/com/woowacourse/moragora/support/EventFixtures.java
@@ -42,4 +42,16 @@ public enum EventFixtures {
                 .meeting(meeting)
                 .build();
     }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public LocalTime getEntranceTime() {
+        return entranceTime;
+    }
+
+    public LocalTime getLeaveTime() {
+        return leaveTime;
+    }
 }


### PR DESCRIPTION
Close #292 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/attendance-find-all -> dev

## 요구사항
<!--로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
- 오늘 날짜의 출석부만 조회할 수 있도록 구현
- 출석부 조회 기능 Test 추가
- 출석 생성 로직 변경 (Scheduling 제거)

## 변경사항
- 출석부 생성 방식이 변경됨
기존에 스케줄링으로 출석부를 생성했는데, 우선 모든 이벤트에 대한 출석을 NONE으로 저장하도록 변경.
- 스케줄링을 아직 지우지 않은 이유는 TARDY로 자동적으로 변경시키도록 하기 위함.

## [Optional] 논의하고 싶은 내용
1. 변경된 출석부 생성 방식
2. 출석부는 모두가 볼 수 있는지
3. 출석부를 조회할 수 있는 시간대
4. AttendanceServiceTest에서 ID 검증 방법? (아래 코드 comment 확인)
