### PR TITLE
[BE] 가장 가까운 이벤트 단일 조회 구현, 미팅 목록 조회 API 수정

### DIFF
--- a/backend/src/docs/asciidoc/event.asciidoc
+++ b/backend/src/docs/asciidoc/event.asciidoc
@@ -1,0 +1,33 @@
+= Event
+:toc: left
+:toclevels: 2
+:sectlinks:
+:source-highlighter: highlightjs
+
+[[home]]
+== home
+
+* link:index.html[홈으로 가기]
+
+[[find-upcoming]]
+== 다가오는 일정 조회
+
+[[find-upcoming-success]]
+=== HTTP request
+
+include::{snippets}/event/find-upcoming/http-request.adoc[]
+
+=== HTTP response
+
+include::{snippets}/event/find-upcoming/http-response.adoc[]
+
+=== Request fields
+
+include::{snippets}/event/find-upcoming/response-fields.adoc[]
+
+[[find-upcoming-not-found]]
+=== 다가오는 일정이 존재하지 않을 경우
+
+include::{snippets}/event/find-upcoming-not-found/http-response.adoc[]
+
+

--- a/backend/src/docs/asciidoc/index.asciidoc
+++ b/backend/src/docs/asciidoc/index.asciidoc
@@ -9,6 +9,7 @@
 * link:auth.html[Auth]
 * link:user.html[User]
 * link:meeting.html[Meeting]
+* link:event.html[Event]
 * link:attendance.html[Attendance]
 * link:common.html[Common]
 

--- a/backend/src/main/java/com/woowacourse/moragora/controller/EventController.java
+++ b/backend/src/main/java/com/woowacourse/moragora/controller/EventController.java
@@ -3,10 +3,12 @@ package com.woowacourse.moragora.controller;
 import com.woowacourse.auth.support.Authentication;
 import com.woowacourse.auth.support.AuthenticationPrincipal;
 import com.woowacourse.auth.support.MasterAuthorization;
+import com.woowacourse.moragora.dto.EventResponse;
 import com.woowacourse.moragora.dto.EventsRequest;
 import com.woowacourse.moragora.service.EventService;
 import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,5 +31,12 @@ public class EventController {
                                     @AuthenticationPrincipal final Long loginId) {
         eventService.save(request, meetingId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/meetings/{meetingId}/events/upcoming")
+    public ResponseEntity<EventResponse> showUpcomingEvent(@PathVariable final Long meetingId,
+                                                           @AuthenticationPrincipal final Long loginId) {
+        final EventResponse eventResponse = eventService.findUpcomingEvent(meetingId);
+        return ResponseEntity.ok(eventResponse);
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/EventRequest.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/EventRequest.java
@@ -20,24 +20,24 @@ public class EventRequest {
 
     @NotNull(message = MISSING_REQUIRED_INPUT)
     @DateTimeFormat(pattern = "'T'HH:mm")
-    private LocalTime entranceTime;
+    private LocalTime meetingStartTime;
 
     @NotNull(message = MISSING_REQUIRED_INPUT)
     @DateTimeFormat(pattern = "'T'HH:mm")
-    private LocalTime leaveTime;
+    private LocalTime meetingEndTime;
 
     @NotNull(message = MISSING_REQUIRED_INPUT)
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 
     @Builder
-    public EventRequest(final LocalTime entranceTime, final LocalTime leaveTime, final LocalDate date) {
-        this.entranceTime = entranceTime;
-        this.leaveTime = leaveTime;
+    public EventRequest(final LocalTime meetingStartTime, final LocalTime meetingEndTime, final LocalDate date) {
+        this.meetingStartTime = meetingStartTime;
+        this.meetingEndTime = meetingEndTime;
         this.date = date;
     }
 
     public Event toEntity(final Meeting meeting) {
-        return new Event(date, entranceTime, leaveTime, meeting);
+        return new Event(date, meetingStartTime, meetingEndTime, meeting);
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/EventResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/EventResponse.java
@@ -5,8 +5,10 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class EventResponse {
 
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
@@ -41,3 +43,4 @@ public class EventResponse {
         );
     }
 }
+

--- a/backend/src/main/java/com/woowacourse/moragora/dto/EventResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/EventResponse.java
@@ -37,8 +37,8 @@ public class EventResponse {
                 event.getId(),
                 attendanceOpenTime.format(TIME_FORMATTER),
                 attendanceClosedTime.format(TIME_FORMATTER),
-                event.getEntranceTime().format(TIME_FORMATTER),
-                event.getLeaveTime().format(TIME_FORMATTER),
+                event.getStartTime().format(TIME_FORMATTER),
+                event.getEndTime().format(TIME_FORMATTER),
                 event.getDate()
         );
     }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/EventResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/EventResponse.java
@@ -1,0 +1,43 @@
+package com.woowacourse.moragora.dto;
+
+import com.woowacourse.moragora.entity.Event;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import lombok.Getter;
+
+@Getter
+public class EventResponse {
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    private final Long id;
+    private final String attendanceOpenTime;
+    private final String attendanceClosedTime;
+    private final String meetingStartTime;
+    private final String meetingEndTime;
+    private final LocalDate date;
+
+    public EventResponse(final Long id, final String attendanceOpenTime, final String attendanceClosedTime,
+                         final String meetingStartTime, final String meetingEndTime, final LocalDate date) {
+        this.id = id;
+        this.attendanceOpenTime = attendanceOpenTime;
+        this.attendanceClosedTime = attendanceClosedTime;
+        this.meetingStartTime = meetingStartTime;
+        this.meetingEndTime = meetingEndTime;
+        this.date = date;
+    }
+
+    public static EventResponse of(final Event event,
+                                   final LocalTime attendanceOpenTime,
+                                   final LocalTime attendanceClosedTime) {
+        return new EventResponse(
+                event.getId(),
+                attendanceOpenTime.format(TIME_FORMATTER),
+                attendanceClosedTime.format(TIME_FORMATTER),
+                event.getEntranceTime().format(TIME_FORMATTER),
+                event.getLeaveTime().format(TIME_FORMATTER),
+                event.getDate()
+        );
+    }
+}

--- a/backend/src/main/java/com/woowacourse/moragora/dto/MyMeetingResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/MyMeetingResponse.java
@@ -1,9 +1,6 @@
 package com.woowacourse.moragora.dto;
 
-import com.woowacourse.moragora.entity.Event;
 import com.woowacourse.moragora.entity.Meeting;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -12,77 +9,42 @@ import lombok.ToString;
 @ToString
 public class MyMeetingResponse {
 
-    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
-    private static final LocalTime MEANINGLESS_TIME_DATA = LocalTime.MIDNIGHT;
-
     private final Long id;
     private final String name;
-    private final Boolean isActive;
-    private final String entranceTime;
-    private final String closingTime;
     private final int tardyCount;
-    private final Boolean isMaster;
+    private final Boolean isLoginUserMaster;
     private final Boolean isCoffeeTime;
-    private final Boolean hasUpcomingEvent;
+    private final Boolean isActive;
+    private final EventResponse upcomingEvent;
 
     @Builder
     public MyMeetingResponse(final Long id,
                              final String name,
-                             final Boolean isActive,
-                             final LocalTime entranceTime,
-                             final LocalTime closingTime,
                              final int tardyCount,
-                             final Boolean isMaster,
+                             final Boolean isLoginUserMaster,
                              final Boolean isCoffeeTime,
-                             final Boolean hasUpcomingEvent) {
+                             final Boolean isActive,
+                             final EventResponse upcomingEvent) {
         this.id = id;
         this.name = name;
-        this.isActive = isActive;
-        this.entranceTime = entranceTime.format(TIME_FORMATTER);
-        this.closingTime = closingTime.format(TIME_FORMATTER);
         this.tardyCount = tardyCount;
-        this.isMaster = isMaster;
+        this.isLoginUserMaster = isLoginUserMaster;
         this.isCoffeeTime = isCoffeeTime;
-        this.hasUpcomingEvent = hasUpcomingEvent;
+        this.isActive = isActive;
+        this.upcomingEvent = upcomingEvent;
     }
 
     public static MyMeetingResponse of(final Meeting meeting,
-                                       final boolean isActive,
-                                       final LocalTime closingTime,
                                        final int tardyCount,
-                                       final Event event,
-                                       final boolean isMaster,
-                                       final boolean isCoffeeTime) {
+                                       final boolean isLoginUserMaster,
+                                       final boolean isCoffeeTime,
+                                       final boolean isActive,
+                                       final EventResponse upcomingEvent) {
 
         return new MyMeetingResponse(
-                meeting.getId(),
-                meeting.getName(),
-                isActive,
-                event.getEntranceTime(),
-                closingTime,
-                tardyCount,
-                isMaster,
-                isCoffeeTime,
-                true
-        );
-    }
-
-    public static MyMeetingResponse whenHasNoUpcomingEventOf(final Meeting meeting,
-                                                             final boolean isActive,
-                                                             final int tardyCount,
-                                                             final boolean isMaster,
-                                                             final boolean isCoffeeTime) {
-
-        return new MyMeetingResponse(
-                meeting.getId(),
-                meeting.getName(),
-                isActive,
-                MEANINGLESS_TIME_DATA,
-                MEANINGLESS_TIME_DATA,
-                tardyCount,
-                isMaster,
-                isCoffeeTime,
-                false
+                meeting.getId(), meeting.getName(),
+                tardyCount, isLoginUserMaster, isCoffeeTime, isActive,
+                upcomingEvent
         );
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/entity/Event.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/Event.java
@@ -30,10 +30,10 @@ public class Event {
     private LocalDate date;
 
     @Column(nullable = false)
-    private LocalTime entranceTime;
+    private LocalTime startTime;
 
     @Column(nullable = false)
-    private LocalTime leaveTime;
+    private LocalTime endTime;
 
     @ManyToOne
     @JoinColumn(name = "meeting_id")
@@ -42,19 +42,19 @@ public class Event {
     @Builder
     public Event(final Long id,
                  final LocalDate date,
-                 final LocalTime entranceTime,
-                 final LocalTime leaveTime,
+                 final LocalTime startTime,
+                 final LocalTime endTime,
                  final Meeting meeting) {
-        validateEntranceLeaveTime(entranceTime, leaveTime);
+        validateEntranceLeaveTime(startTime, endTime);
         this.id = id;
         this.date = date;
-        this.entranceTime = entranceTime;
-        this.leaveTime = leaveTime;
+        this.startTime = startTime;
+        this.endTime = endTime;
         this.meeting = meeting;
     }
 
-    public Event(final LocalDate date, final LocalTime entranceTime, final LocalTime leaveTime, final Meeting meeting) {
-        this(null, date, entranceTime, leaveTime, meeting);
+    public Event(final LocalDate date, final LocalTime startTime, final LocalTime endTime, final Meeting meeting) {
+        this(null, date, startTime, endTime, meeting);
     }
 
     public boolean isSameDate(final LocalDate date) {

--- a/backend/src/main/java/com/woowacourse/moragora/service/AttendanceService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/AttendanceService.java
@@ -108,7 +108,7 @@ public class AttendanceService {
         final LocalDate today = serverTimeManager.getDate();
         final Event event = eventRepository.findByMeetingIdAndDate(meetingId, today)
                 .orElse(null);
-        final boolean isOver = Objects.isNull(event) || serverTimeManager.isOverClosingTime(event.getStartTime());
+        final boolean isOver = Objects.isNull(event) || serverTimeManager.isAttendanceClosed(event.getStartTime());
 
         final MeetingAttendances meetingAttendances = findMeetingAttendancesBy(meetingId);
         validateEnoughTardyCountToDisable(meetingAttendances, isOver, today);
@@ -121,7 +121,7 @@ public class AttendanceService {
         final LocalDate today = serverTimeManager.getDate();
         final Event event = eventRepository.findByMeetingIdAndDate(meetingId, today)
                 .orElse(null);
-        final boolean isOver = Objects.isNull(event) || serverTimeManager.isOverClosingTime(event.getStartTime());
+        final boolean isOver = Objects.isNull(event) || serverTimeManager.isAttendanceClosed(event.getStartTime());
 
         final MeetingAttendances meetingAttendances = findMeetingAttendancesBy(meetingId);
         validateEnoughTardyCountToDisable(meetingAttendances, isOver, today);
@@ -131,7 +131,7 @@ public class AttendanceService {
     private void validateAttendanceTime(final Event event) {
         final LocalTime entranceTime = event.getStartTime();
 
-        if (!serverTimeManager.isAttendanceTime(entranceTime)) {
+        if (!serverTimeManager.isAttendanceOpen(entranceTime)) {
             throw new NotCheckInTimeException();
         }
     }

--- a/backend/src/main/java/com/woowacourse/moragora/service/AttendanceService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/AttendanceService.java
@@ -15,8 +15,8 @@ import com.woowacourse.moragora.exception.ClientRuntimeException;
 import com.woowacourse.moragora.exception.InvalidCoffeeTimeException;
 import com.woowacourse.moragora.exception.event.EventNotFoundException;
 import com.woowacourse.moragora.exception.meeting.AttendanceNotFoundException;
-import com.woowacourse.moragora.exception.meeting.NotCheckInTimeException;
 import com.woowacourse.moragora.exception.meeting.MeetingNotFoundException;
+import com.woowacourse.moragora.exception.meeting.NotCheckInTimeException;
 import com.woowacourse.moragora.exception.participant.ParticipantNotFoundException;
 import com.woowacourse.moragora.exception.user.UserNotFoundException;
 import com.woowacourse.moragora.repository.AttendanceRepository;
@@ -108,7 +108,7 @@ public class AttendanceService {
         final LocalDate today = serverTimeManager.getDate();
         final Event event = eventRepository.findByMeetingIdAndDate(meetingId, today)
                 .orElse(null);
-        final boolean isOver = Objects.isNull(event) || serverTimeManager.isOverClosingTime(event.getEntranceTime());
+        final boolean isOver = Objects.isNull(event) || serverTimeManager.isOverClosingTime(event.getStartTime());
 
         final MeetingAttendances meetingAttendances = findMeetingAttendancesBy(meetingId);
         validateEnoughTardyCountToDisable(meetingAttendances, isOver, today);
@@ -121,7 +121,7 @@ public class AttendanceService {
         final LocalDate today = serverTimeManager.getDate();
         final Event event = eventRepository.findByMeetingIdAndDate(meetingId, today)
                 .orElse(null);
-        final boolean isOver = Objects.isNull(event) || serverTimeManager.isOverClosingTime(event.getEntranceTime());
+        final boolean isOver = Objects.isNull(event) || serverTimeManager.isOverClosingTime(event.getStartTime());
 
         final MeetingAttendances meetingAttendances = findMeetingAttendancesBy(meetingId);
         validateEnoughTardyCountToDisable(meetingAttendances, isOver, today);
@@ -129,7 +129,7 @@ public class AttendanceService {
     }
 
     private void validateAttendanceTime(final Event event) {
-        final LocalTime entranceTime = event.getEntranceTime();
+        final LocalTime entranceTime = event.getStartTime();
 
         if (!serverTimeManager.isAttendanceTime(entranceTime)) {
             throw new NotCheckInTimeException();

--- a/backend/src/main/java/com/woowacourse/moragora/service/EventService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/EventService.java
@@ -1,15 +1,19 @@
 package com.woowacourse.moragora.service;
 
+import com.woowacourse.moragora.dto.EventResponse;
 import com.woowacourse.moragora.dto.EventsRequest;
 import com.woowacourse.moragora.entity.Attendance;
 import com.woowacourse.moragora.entity.Event;
 import com.woowacourse.moragora.entity.Meeting;
 import com.woowacourse.moragora.entity.Participant;
 import com.woowacourse.moragora.entity.Status;
+import com.woowacourse.moragora.exception.event.EventNotFoundException;
 import com.woowacourse.moragora.exception.meeting.MeetingNotFoundException;
 import com.woowacourse.moragora.repository.AttendanceRepository;
 import com.woowacourse.moragora.repository.EventRepository;
 import com.woowacourse.moragora.repository.MeetingRepository;
+import com.woowacourse.moragora.support.ServerTimeManager;
+import java.time.LocalTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -31,15 +35,18 @@ public class EventService {
     private final EventRepository eventRepository;
     private final MeetingRepository meetingRepository;
     private final AttendanceRepository attendanceRepository;
+    private final ServerTimeManager serverTimeManager;
 
     public EventService(final TaskScheduler taskScheduler,
                         final EventRepository eventRepository,
                         final MeetingRepository meetingRepository,
-                        final AttendanceRepository attendanceRepository) {
+                        final AttendanceRepository attendanceRepository,
+                        final ServerTimeManager serverTimeManager) {
         this.taskScheduler = taskScheduler;
         this.eventRepository = eventRepository;
         this.meetingRepository = meetingRepository;
         this.attendanceRepository = attendanceRepository;
+        this.serverTimeManager = serverTimeManager;
     }
 
     @Transactional
@@ -64,5 +71,16 @@ public class EventService {
         return participants.stream()
                 .map(participant -> new Attendance(Status.NONE, false, participant, event))
                 .collect(Collectors.toList());
+    }
+
+    public EventResponse findUpcomingEvent(final Long meetingId) {
+        final Event event = eventRepository.findFirstByMeetingIdAndDateGreaterThanEqualOrderByDate(
+                        meetingId, serverTimeManager.getDate())
+                .orElseThrow(EventNotFoundException::new);
+
+        final LocalTime entranceTime = event.getEntranceTime();
+        final LocalTime attendanceOpenTime = serverTimeManager.calculateOpeningTime(entranceTime);
+        final LocalTime attendanceClosedTime = serverTimeManager.calculateClosingTime(entranceTime);
+        return EventResponse.of(event, attendanceOpenTime, attendanceClosedTime);
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/service/EventService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/EventService.java
@@ -78,7 +78,7 @@ public class EventService {
                         meetingId, serverTimeManager.getDate())
                 .orElseThrow(EventNotFoundException::new);
 
-        final LocalTime entranceTime = event.getEntranceTime();
+        final LocalTime entranceTime = event.getStartTime();
         final LocalTime attendanceOpenTime = serverTimeManager.calculateOpeningTime(entranceTime);
         final LocalTime attendanceClosedTime = serverTimeManager.calculateClosingTime(entranceTime);
         return EventResponse.of(event, attendanceOpenTime, attendanceClosedTime);

--- a/backend/src/main/java/com/woowacourse/moragora/service/EventService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/EventService.java
@@ -79,8 +79,8 @@ public class EventService {
                 .orElseThrow(EventNotFoundException::new);
 
         final LocalTime entranceTime = event.getStartTime();
-        final LocalTime attendanceOpenTime = serverTimeManager.calculateOpeningTime(entranceTime);
-        final LocalTime attendanceClosedTime = serverTimeManager.calculateClosingTime(entranceTime);
+        final LocalTime attendanceOpenTime = serverTimeManager.calculateOpenTime(entranceTime);
+        final LocalTime attendanceClosedTime = serverTimeManager.calculateClosedTime(entranceTime);
         return EventResponse.of(event, attendanceOpenTime, attendanceClosedTime);
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
@@ -84,8 +84,8 @@ public class MeetingService {
 
         final LocalDate today = serverTimeManager.getDate();
         final Optional<Event> event = eventRepository.findByMeetingIdAndDate(meeting.getId(), today);
-        final boolean isActive = event.isPresent() && serverTimeManager.isAttendanceTime(event.get().getEntranceTime());
-        final boolean isOver = event.isPresent() && serverTimeManager.isOverClosingTime(event.get().getEntranceTime());
+        final boolean isActive = event.isPresent() && serverTimeManager.isAttendanceTime(event.get().getStartTime());
+        final boolean isOver = event.isPresent() && serverTimeManager.isOverClosingTime(event.get().getStartTime());
 
         final MeetingAttendances meetingAttendances = findAttendancesByMeeting(meeting.getParticipantIds());
         final List<ParticipantResponse> participantResponses = participants.stream()
@@ -178,10 +178,10 @@ public class MeetingService {
         final Optional<Event> upcomingEvent = eventRepository
                 .findFirstByMeetingIdAndDateGreaterThanEqualOrderByDate(meeting.getId(), today);
         final boolean isActive =
-                upcomingEvent.isPresent() && serverTimeManager.isAttendanceTime(upcomingEvent.get().getEntranceTime());
+                upcomingEvent.isPresent() && serverTimeManager.isAttendanceTime(upcomingEvent.get().getStartTime());
 
         final boolean isOver =
-                upcomingEvent.isPresent() && serverTimeManager.isOverClosingTime(upcomingEvent.get().getEntranceTime());
+                upcomingEvent.isPresent() && serverTimeManager.isOverClosingTime(upcomingEvent.get().getStartTime());
         final boolean isCoffeeTime = meetingAttendances.isTardyStackFull(isOver, today);
         final int tardyCount = participantAttendances.countTardy(isOver, today);
 
@@ -191,7 +191,7 @@ public class MeetingService {
             );
         }
         final Event event = upcomingEvent.get();
-        final LocalTime entranceTime = event.getEntranceTime();
+        final LocalTime entranceTime = event.getStartTime();
         final LocalTime attendanceOpenTime = serverTimeManager.calculateOpeningTime(entranceTime);
         final LocalTime attendanceClosedTime = serverTimeManager.calculateClosingTime(entranceTime);
         return MyMeetingResponse.of(

--- a/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
@@ -84,8 +84,8 @@ public class MeetingService {
 
         final LocalDate today = serverTimeManager.getDate();
         final Optional<Event> event = eventRepository.findByMeetingIdAndDate(meeting.getId(), today);
-        final boolean isActive = event.isPresent() && serverTimeManager.isAttendanceTime(event.get().getStartTime());
-        final boolean isOver = event.isPresent() && serverTimeManager.isOverClosingTime(event.get().getStartTime());
+        final boolean isActive = event.isPresent() && serverTimeManager.isAttendanceOpen(event.get().getStartTime());
+        final boolean isOver = event.isPresent() && serverTimeManager.isAttendanceClosed(event.get().getStartTime());
 
         final MeetingAttendances meetingAttendances = findAttendancesByMeeting(meeting.getParticipantIds());
         final List<ParticipantResponse> participantResponses = participants.stream()
@@ -178,10 +178,10 @@ public class MeetingService {
         final Optional<Event> upcomingEvent = eventRepository
                 .findFirstByMeetingIdAndDateGreaterThanEqualOrderByDate(meeting.getId(), today);
         final boolean isActive =
-                upcomingEvent.isPresent() && serverTimeManager.isAttendanceTime(upcomingEvent.get().getStartTime());
+                upcomingEvent.isPresent() && serverTimeManager.isAttendanceOpen(upcomingEvent.get().getStartTime());
 
         final boolean isOver =
-                upcomingEvent.isPresent() && serverTimeManager.isOverClosingTime(upcomingEvent.get().getStartTime());
+                upcomingEvent.isPresent() && serverTimeManager.isAttendanceClosed(upcomingEvent.get().getStartTime());
         final boolean isCoffeeTime = meetingAttendances.isTardyStackFull(isOver, today);
         final int tardyCount = participantAttendances.countTardy(isOver, today);
 
@@ -192,8 +192,8 @@ public class MeetingService {
         }
         final Event event = upcomingEvent.get();
         final LocalTime entranceTime = event.getStartTime();
-        final LocalTime attendanceOpenTime = serverTimeManager.calculateOpeningTime(entranceTime);
-        final LocalTime attendanceClosedTime = serverTimeManager.calculateClosingTime(entranceTime);
+        final LocalTime attendanceOpenTime = serverTimeManager.calculateOpenTime(entranceTime);
+        final LocalTime attendanceClosedTime = serverTimeManager.calculateClosedTime(entranceTime);
         return MyMeetingResponse.of(
                 meeting, tardyCount, isLoginUserMaster, isCoffeeTime, isActive,
                 EventResponse.of(event, attendanceOpenTime, attendanceClosedTime)

--- a/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/service/MeetingService.java
@@ -1,5 +1,6 @@
 package com.woowacourse.moragora.service;
 
+import com.woowacourse.moragora.dto.EventResponse;
 import com.woowacourse.moragora.dto.MeetingRequest;
 import com.woowacourse.moragora.dto.MeetingResponse;
 import com.woowacourse.moragora.dto.MyMeetingResponse;
@@ -171,28 +172,31 @@ public class MeetingService {
         final Meeting meeting = participant.getMeeting();
         final ParticipantAttendances participantAttendances = meetingAttendances
                 .extractAttendancesByParticipant(participant);
+        final boolean isLoginUserMaster = participant.getIsMaster();
 
         final LocalDate today = serverTimeManager.getDate();
-        final boolean hasUpcomingEvent =
-                eventRepository.countByMeetingIdAndDateGreaterThanEqual(meeting.getId(), today) > 0;
-        final Event event = eventRepository
-                .findFirstByMeetingIdAndDateGreaterThanEqualOrderByDate(meeting.getId(), today)
-                .orElse(null);
-        final boolean hasEventToday = hasUpcomingEvent && event.isSameDate(today);
-        final boolean isActive = hasEventToday && serverTimeManager.isAttendanceTime(event.getEntranceTime());
-        final boolean isOver = !hasEventToday || serverTimeManager.isOverClosingTime(event.getEntranceTime());
+        final Optional<Event> upcomingEvent = eventRepository
+                .findFirstByMeetingIdAndDateGreaterThanEqualOrderByDate(meeting.getId(), today);
+        final boolean isActive =
+                upcomingEvent.isPresent() && serverTimeManager.isAttendanceTime(upcomingEvent.get().getEntranceTime());
 
+        final boolean isOver =
+                upcomingEvent.isPresent() && serverTimeManager.isOverClosingTime(upcomingEvent.get().getEntranceTime());
+        final boolean isCoffeeTime = meetingAttendances.isTardyStackFull(isOver, today);
         final int tardyCount = participantAttendances.countTardy(isOver, today);
-        if (hasUpcomingEvent) {
-            final LocalTime entranceTime = event.getEntranceTime();
-            final LocalTime closingTime = serverTimeManager.calculateClosingTime(entranceTime);
+
+        if (upcomingEvent.isEmpty()) {
             return MyMeetingResponse.of(
-                    meeting, isActive, closingTime, tardyCount, event,
-                    participant.getIsMaster(), meetingAttendances.isTardyStackFull(isOver, today)
+                    meeting, tardyCount, isLoginUserMaster, isCoffeeTime, isActive, null
             );
         }
-        return MyMeetingResponse.whenHasNoUpcomingEventOf(
-                meeting, isActive, tardyCount,
-                participant.getIsMaster(), meetingAttendances.isTardyStackFull(isOver, today));
+        final Event event = upcomingEvent.get();
+        final LocalTime entranceTime = event.getEntranceTime();
+        final LocalTime attendanceOpenTime = serverTimeManager.calculateOpeningTime(entranceTime);
+        final LocalTime attendanceClosedTime = serverTimeManager.calculateClosingTime(entranceTime);
+        return MyMeetingResponse.of(
+                meeting, tardyCount, isLoginUserMaster, isCoffeeTime, isActive,
+                EventResponse.of(event, attendanceOpenTime, attendanceClosedTime)
+        );
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/support/ServerTimeManager.java
+++ b/backend/src/main/java/com/woowacourse/moragora/support/ServerTimeManager.java
@@ -21,24 +21,24 @@ public class ServerTimeManager {
         this.dateTime = dateTime;
     }
 
-    public boolean isAttendanceTime(final LocalTime entranceTime) {
-        final LocalTime attendanceStartTime = entranceTime.minusMinutes(ATTENDANCE_START_INTERVAL);
-        final LocalTime attendanceClosingTime = entranceTime.plusMinutes(ATTENDANCE_END_INTERVAL);
+    public boolean isAttendanceOpen(final LocalTime meetingStartTime) {
+        final LocalTime attendanceOpenTime = meetingStartTime.minusMinutes(ATTENDANCE_START_INTERVAL);
+        final LocalTime attendanceClosedTime = meetingStartTime.plusMinutes(ATTENDANCE_END_INTERVAL);
 
-        return dateTime.isBetween(attendanceStartTime, attendanceClosingTime);
+        return dateTime.isBetween(attendanceOpenTime, attendanceClosedTime);
     }
 
-    public boolean isOverClosingTime(final LocalTime entranceTime) {
-        final LocalTime closingTime = entranceTime.plusMinutes(ATTENDANCE_END_INTERVAL);
+    public boolean isAttendanceClosed(final LocalTime meetingStartTime) {
+        final LocalTime closingTime = meetingStartTime.plusMinutes(ATTENDANCE_END_INTERVAL);
         return dateTime.isAfter(closingTime);
     }
 
-    public LocalTime calculateOpeningTime(final LocalTime entranceTime) {
-        return entranceTime.minusMinutes(ATTENDANCE_START_INTERVAL);
+    public LocalTime calculateOpenTime(final LocalTime meetingStartTime) {
+        return meetingStartTime.minusMinutes(ATTENDANCE_START_INTERVAL);
     }
 
-    public LocalTime calculateClosingTime(final LocalTime entranceTime) {
-        return entranceTime.plusMinutes(ATTENDANCE_END_INTERVAL);
+    public LocalTime calculateClosedTime(final LocalTime meetingStartTime) {
+        return meetingStartTime.plusMinutes(ATTENDANCE_END_INTERVAL);
     }
 
     public void refresh(final LocalDateTime localDateTime) {

--- a/backend/src/main/java/com/woowacourse/moragora/support/ServerTimeManager.java
+++ b/backend/src/main/java/com/woowacourse/moragora/support/ServerTimeManager.java
@@ -33,6 +33,10 @@ public class ServerTimeManager {
         return dateTime.isAfter(closingTime);
     }
 
+    public LocalTime calculateOpeningTime(final LocalTime entranceTime) {
+        return entranceTime.minusMinutes(ATTENDANCE_START_INTERVAL);
+    }
+
     public LocalTime calculateClosingTime(final LocalTime entranceTime) {
         return entranceTime.plusMinutes(ATTENDANCE_END_INTERVAL);
     }

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/AcceptanceTest.java
@@ -147,7 +147,7 @@ public class AcceptanceTest {
 
     protected void saveEvents(final String token, final List<Event> events, final Long meetingId) {
         final List<EventRequest> eventRequests = events.stream()
-                .map(event -> new EventRequest(event.getEntranceTime(), event.getLeaveTime(), event.getDate()))
+                .map(event -> new EventRequest(event.getStartTime(), event.getEndTime(), event.getDate()))
                 .collect(Collectors.toList());
 
         EventsRequest eventsRequest = new EventsRequest(eventRequests);

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/AttendanceAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/AttendanceAcceptanceTest.java
@@ -89,7 +89,7 @@ class AttendanceAcceptanceTest extends AcceptanceTest {
 
         final LocalDateTime dateTime = LocalDateTime.of(2022, 8, 1, 10, 1);
 
-        given(serverTimeManager.isAttendanceTime(any(LocalTime.class)))
+        given(serverTimeManager.isAttendanceOpen(any(LocalTime.class)))
                 .willReturn(true);
         given(serverTimeManager.getDate())
                 .willReturn(dateTime.toLocalDate());
@@ -120,7 +120,7 @@ class AttendanceAcceptanceTest extends AcceptanceTest {
 
         final LocalDateTime dateTime = LocalDateTime.of(2022, 8, 1, 10, 1);
 
-        given(serverTimeManager.isOverClosingTime(any(LocalTime.class)))
+        given(serverTimeManager.isAttendanceClosed(any(LocalTime.class)))
                 .willReturn(false);
         given(serverTimeManager.getDate())
                 .willReturn(dateTime.toLocalDate());

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/EventAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/EventAcceptanceTest.java
@@ -45,13 +45,13 @@ class EventAcceptanceTest extends AcceptanceTest {
         final EventsRequest eventsRequest = new EventsRequest(
                 List.of(
                         new EventRequest(
-                                event1.getEntranceTime(),
-                                event1.getLeaveTime(),
+                                event1.getStartTime(),
+                                event1.getEndTime(),
                                 event1.getDate()
                         ),
                         new EventRequest(
-                                event2.getEntranceTime(),
-                                event2.getLeaveTime(),
+                                event2.getStartTime(),
+                                event2.getEndTime(),
                                 event2.getDate()
                         )
                 ));
@@ -81,10 +81,10 @@ class EventAcceptanceTest extends AcceptanceTest {
 
         given(serverTimeManager.getDate())
                 .willReturn(LocalDate.of(2022, 7, 31));
-        given(serverTimeManager.calculateOpeningTime(event1.getEntranceTime()))
-                .willReturn(event1.getEntranceTime().minusMinutes(30));
-        given(serverTimeManager.calculateClosingTime(event1.getEntranceTime()))
-                .willReturn(event1.getEntranceTime().plusMinutes(5));
+        given(serverTimeManager.calculateOpeningTime(event1.getStartTime()))
+                .willReturn(event1.getStartTime().minusMinutes(30));
+        given(serverTimeManager.calculateClosingTime(event1.getStartTime()))
+                .willReturn(event1.getStartTime().plusMinutes(5));
 
         // when
         final ValidatableResponse response = get("/meetings/" + meetingId + "/events/upcoming", token);

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/EventAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/EventAcceptanceTest.java
@@ -5,19 +5,27 @@ import static com.woowacourse.moragora.support.EventFixtures.EVENT2;
 import static com.woowacourse.moragora.support.MeetingFixtures.MORAGORA;
 import static com.woowacourse.moragora.support.UserFixtures.AZPI;
 import static com.woowacourse.moragora.support.UserFixtures.KUN;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.BDDMockito.given;
 
 import com.woowacourse.moragora.dto.EventRequest;
 import com.woowacourse.moragora.dto.EventsRequest;
 import com.woowacourse.moragora.entity.Event;
 import com.woowacourse.moragora.entity.Meeting;
 import com.woowacourse.moragora.entity.user.User;
+import com.woowacourse.moragora.support.ServerTimeManager;
 import io.restassured.response.ValidatableResponse;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 
 class EventAcceptanceTest extends AcceptanceTest {
+
+    @MockBean
+    private ServerTimeManager serverTimeManager;
 
     @DisplayName("특정 모임에 대한 일정들을 등록하고 상태코드 200을 반환한다.")
     @Test
@@ -53,5 +61,68 @@ class EventAcceptanceTest extends AcceptanceTest {
 
         // then
         response.statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @DisplayName("모임의 가장 가까운 일정을 요청하면 일정 상세 정보와 상태코드 200을 반환한다.")
+    @Test
+    void show_upcoming_event() {
+        // given
+        final User user1 = KUN.create();
+        final User user2 = AZPI.create();
+        final List<Long> userIds = saveUsers(List.of(user2));
+
+        final String token = signUpAndGetToken(user1);
+        final Meeting meeting = MORAGORA.create();
+        final int meetingId = saveMeeting(token, userIds, meeting);
+
+        final Event event1 = EVENT1.create(meeting);
+        final Event event2 = EVENT2.create(meeting);
+        saveEvents(token, List.of(event1, event2), (long) meetingId);
+
+        given(serverTimeManager.getDate())
+                .willReturn(LocalDate.of(2022, 7, 31));
+        given(serverTimeManager.calculateOpeningTime(event1.getEntranceTime()))
+                .willReturn(event1.getEntranceTime().minusMinutes(30));
+        given(serverTimeManager.calculateClosingTime(event1.getEntranceTime()))
+                .willReturn(event1.getEntranceTime().plusMinutes(5));
+
+        // when
+        final ValidatableResponse response = get("/meetings/" + meetingId + "/events/upcoming", token);
+
+        // then
+        response.statusCode(HttpStatus.OK.value())
+                .body("id", equalTo(1))
+                .body("attendanceOpenTime", equalTo("09:30"))
+                .body("attendanceClosedTime", equalTo("10:05"))
+                .body("meetingStartTime", equalTo("10:00"))
+                .body("meetingEndTime", equalTo("18:00"))
+                .body("date", equalTo("2022-08-01"));
+    }
+
+    @DisplayName("모임의 가장 가까운 일정이 존재하지 않은 경우에  일정 상세 정보와 상태코드 404를 반환한다.")
+    @Test
+    void showUpcomingEvent_ifEventNotFound() {
+        // given
+        final User user1 = KUN.create();
+        final User user2 = AZPI.create();
+        final List<Long> userIds = saveUsers(List.of(user2));
+
+        final String token = signUpAndGetToken(user1);
+        final Meeting meeting = MORAGORA.create();
+        final int meetingId = saveMeeting(token, userIds, meeting);
+
+        final Event event1 = EVENT1.create(meeting);
+        final Event event2 = EVENT2.create(meeting);
+        saveEvents(token, List.of(event1, event2), (long) meetingId);
+
+        given(serverTimeManager.getDate())
+                .willReturn(LocalDate.of(2022, 8, 3));
+
+        // when
+        final ValidatableResponse response = get("/meetings/" + meetingId + "/events/upcoming", token);
+
+        // then
+        response.statusCode(HttpStatus.NOT_FOUND.value())
+                .body("message", equalTo("일정이 존재하지 않습니다."));
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/EventAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/EventAcceptanceTest.java
@@ -81,9 +81,9 @@ class EventAcceptanceTest extends AcceptanceTest {
 
         given(serverTimeManager.getDate())
                 .willReturn(LocalDate.of(2022, 7, 31));
-        given(serverTimeManager.calculateOpeningTime(event1.getStartTime()))
+        given(serverTimeManager.calculateOpenTime(event1.getStartTime()))
                 .willReturn(event1.getStartTime().minusMinutes(30));
-        given(serverTimeManager.calculateClosingTime(event1.getStartTime()))
+        given(serverTimeManager.calculateClosedTime(event1.getStartTime()))
                 .willReturn(event1.getStartTime().plusMinutes(5));
 
         // when

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
@@ -117,9 +117,9 @@ public class MeetingAcceptanceTest extends AcceptanceTest {
                 .willReturn(true);
         given(serverTimeManager.isOverClosingTime(any(LocalTime.class)))
                 .willReturn(false);
-        given(serverTimeManager.calculateOpeningTime(event.getEntranceTime()))
+        given(serverTimeManager.calculateOpeningTime(event.getStartTime()))
                 .willReturn(LocalTime.of(9, 30));
-        given(serverTimeManager.calculateClosingTime(event.getEntranceTime()))
+        given(serverTimeManager.calculateClosingTime(event.getStartTime()))
                 .willReturn(LocalTime.of(10, 5));
 
         // when

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
@@ -113,13 +113,13 @@ public class MeetingAcceptanceTest extends AcceptanceTest {
 
         given(serverTimeManager.getDate())
                 .willReturn(event.getDate());
-        given(serverTimeManager.isAttendanceTime(LocalTime.of(10, 0)))
+        given(serverTimeManager.isAttendanceOpen(LocalTime.of(10, 0)))
                 .willReturn(true);
-        given(serverTimeManager.isOverClosingTime(any(LocalTime.class)))
+        given(serverTimeManager.isAttendanceClosed(any(LocalTime.class)))
                 .willReturn(false);
-        given(serverTimeManager.calculateOpeningTime(event.getStartTime()))
+        given(serverTimeManager.calculateOpenTime(event.getStartTime()))
                 .willReturn(LocalTime.of(9, 30));
-        given(serverTimeManager.calculateClosingTime(event.getStartTime()))
+        given(serverTimeManager.calculateClosedTime(event.getStartTime()))
                 .willReturn(LocalTime.of(10, 5));
 
         // when

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
@@ -1,20 +1,27 @@
 package com.woowacourse.moragora.acceptance;
 
+import static com.woowacourse.moragora.support.EventFixtures.EVENT1;
+import static com.woowacourse.moragora.support.MeetingFixtures.F12;
 import static com.woowacourse.moragora.support.MeetingFixtures.MORAGORA;
+import static com.woowacourse.moragora.support.UserFixtures.KUN;
 import static com.woowacourse.moragora.support.UserFixtures.MASTER;
 import static com.woowacourse.moragora.support.UserFixtures.createUsers;
 import static com.woowacourse.moragora.support.UserFixtures.getEmailsIncludingMaster;
 import static com.woowacourse.moragora.support.UserFixtures.getNicknamesIncludingMaster;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.woowacourse.moragora.dto.MeetingRequest;
+import com.woowacourse.moragora.entity.Event;
 import com.woowacourse.moragora.entity.Meeting;
 import com.woowacourse.moragora.entity.user.User;
 import com.woowacourse.moragora.support.ServerTimeManager;
 import io.restassured.response.ValidatableResponse;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
@@ -86,39 +93,53 @@ public class MeetingAcceptanceTest extends AcceptanceTest {
                 .body("users.nickname", equalTo(getNicknamesIncludingMaster()))
                 .body("users.email", equalTo(getEmailsIncludingMaster()));
     }
-//
-//    @DisplayName("사용자가 자신이 속한 모든 모임을 조회하면 모임 정보와 상태코드 200을 반환한다.")
-//    @Test
-//    void findMy() {
-//        // given
-//        final String token = signUpAndGetToken(MASTER.create());
-//        final Meeting meeting1 = MORAGORA.create();
-//        final Meeting meeting2 = F12.create();
-//
-//        final User user = KUN.create();
-//        final List<Long> ids = saveUsers(List.of(user));
-//
-//        final int meetingId1 = saveMeeting(token, ids, meeting1);
-//        final int meetingId2 = saveMeeting(token, ids, meeting2);
-//
-//        given(serverTimeManager.isAttendanceTime(LocalTime.of(10, 0)))
-//                .willReturn(false);
-//        given(serverTimeManager.isAttendanceTime(LocalTime.of(9, 0)))
-//                .willReturn(true);
-//        given(serverTimeManager.isOverClosingTime(any(LocalTime.class)))
-//                .willReturn(true);
-//        given(serverTimeManager.calculateClosingTime(LocalTime.of(10, 0)))
-//                .willReturn(LocalTime.of(10, 5));
-//        given(serverTimeManager.calculateClosingTime(LocalTime.of(9, 0)))
-//                .willReturn(LocalTime.of(9, 5));
-//
-//        // when
-//        final ValidatableResponse response = get("/meetings/me", token);
-//
-//        // then
-//        response.statusCode(HttpStatus.OK.value())
-//                .body("meetings.id", containsInAnyOrder(meetingId1, meetingId2))
-//                .body("meetings.name", containsInAnyOrder(meeting1.getName(), meeting2.getName()))
-//                .body("meetings.tardyCount", containsInAnyOrder(0, 0));
-//    }
+
+    @DisplayName("사용자가 자신이 속한 모든 모임을 조회하면 모임 정보와 상태코드 200을 반환한다.")
+    @Test
+    void findMy() {
+        // given
+        final String token = signUpAndGetToken(MASTER.create());
+        final Meeting meeting1 = MORAGORA.create();
+        final Meeting meeting2 = F12.create();
+
+        final User user = KUN.create();
+        final List<Long> ids = saveUsers(List.of(user));
+
+        final int meetingId1 = saveMeeting(token, ids, meeting1);
+        final int meetingId2 = saveMeeting(token, ids, meeting2);
+
+        final Event event = EVENT1.create(meeting1);
+        saveEvents(token, List.of(event), (long) meetingId1);
+
+        given(serverTimeManager.getDate())
+                .willReturn(event.getDate());
+        given(serverTimeManager.isAttendanceTime(LocalTime.of(10, 0)))
+                .willReturn(true);
+        given(serverTimeManager.isOverClosingTime(any(LocalTime.class)))
+                .willReturn(false);
+        given(serverTimeManager.calculateOpeningTime(event.getEntranceTime()))
+                .willReturn(LocalTime.of(9, 30));
+        given(serverTimeManager.calculateClosingTime(event.getEntranceTime()))
+                .willReturn(LocalTime.of(10, 5));
+
+        // when
+        final ValidatableResponse response = get("/meetings/me", token);
+
+        // then
+        response.statusCode(HttpStatus.OK.value())
+                .body("meetings.id", containsInAnyOrder(meetingId1, meetingId2))
+                .body("meetings.name", containsInAnyOrder(meeting1.getName(), meeting2.getName()))
+                .body("meetings.tardyCount", containsInAnyOrder(0, 0))
+                .body("meetings.isLoginUserMaster", containsInAnyOrder(true, true))
+                .body("meetings.isCoffeeTime", containsInAnyOrder(false, false))
+                .body("meetings.isActive", containsInAnyOrder(true, false))
+                .body("meetings.find{it.id == " + meetingId1 + "}.upcomingEvent.id", equalTo(1))
+                .body("meetings.find{it.id == " + meetingId1 + "}.upcomingEvent.attendanceOpenTime", equalTo("09:30"))
+                .body("meetings.find{it.id == " + meetingId1 + "}.upcomingEvent.attendanceClosedTime", equalTo("10:05"))
+                .body("meetings.find{it.id == " + meetingId1 + "}.upcomingEvent.meetingStartTime", equalTo("10:00"))
+                .body("meetings.find{it.id == " + meetingId1 + "}.upcomingEvent.meetingEndTime", equalTo("18:00"))
+                .body("meetings.find{it.id == " + meetingId1 + "}.upcomingEvent.date", equalTo("2022-08-01"))
+                .body("meetings.find{it.id == " + meetingId2 + "}.upcomingEvent", equalTo(null))
+        ;
+    }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
@@ -361,7 +361,6 @@ class MeetingControllerTest extends ControllerTest {
         performGet("/meetings/me")
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.meetings[*].id", containsInAnyOrder(1)))
-                // 더 이상 일정이 없는 모임
                 .andExpect(jsonPath("$.meetings[*].name", contains("모임1")))
                 .andExpect(jsonPath("$.meetings[*].tardyCount", contains(2)))
                 .andExpect(jsonPath("$.meetings[*].isLoginUserMaster", contains(true)))

--- a/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/controller/MeetingControllerTest.java
@@ -4,6 +4,7 @@ import static com.woowacourse.moragora.support.MeetingFixtures.MORAGORA;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -15,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.moragora.dto.EventResponse;
 import com.woowacourse.moragora.dto.MeetingRequest;
 import com.woowacourse.moragora.dto.MeetingResponse;
 import com.woowacourse.moragora.dto.MyMeetingResponse;
@@ -24,6 +26,7 @@ import com.woowacourse.moragora.entity.Meeting;
 import com.woowacourse.moragora.exception.meeting.IllegalEntranceLeaveTimeException;
 import com.woowacourse.moragora.exception.participant.InvalidParticipantException;
 import com.woowacourse.moragora.exception.user.UserNotFoundException;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -278,19 +281,15 @@ class MeetingControllerTest extends ControllerTest {
     void findAllByUserId() throws Exception {
         // given
         final MyMeetingResponse myMeetingResponse =
-                new MyMeetingResponse(1L, "모임1", false,
-                        LocalTime.of(0, 0),
-                        LocalTime.of(0, 0),
-                        1, true, false, false);
-
-        final MyMeetingResponse myMeetingResponse2 =
-                new MyMeetingResponse(2L, "모임2", true,
-                        LocalTime.of(9, 0),
-                        LocalTime.of(9, 5),
-                        2, true, false, true);
-
+                new MyMeetingResponse(1L, "모임1", 1, true, false, false,
+                        new EventResponse(1L,
+                                "09:30", "10:05",
+                                "10:00", "18:00",
+                                LocalDate.of(2022, 8, 1)
+                        )
+                );
         final MyMeetingsResponse meetingsResponse =
-                new MyMeetingsResponse(List.of(myMeetingResponse, myMeetingResponse2));
+                new MyMeetingsResponse(List.of(myMeetingResponse));
 
         validateToken("1");
 
@@ -301,43 +300,73 @@ class MeetingControllerTest extends ControllerTest {
         // then
         performGet("/meetings/me")
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.meetings[*].id", containsInAnyOrder(1, 2)))
-                // 더 이상 일정이 없는 모임
-                .andExpect(jsonPath("$.meetings[?(@.id=='1')].name", contains("모임1")))
-                .andExpect(jsonPath("$.meetings[?(@.id=='1')].isActive", contains(false)))
-                .andExpect(jsonPath("$.meetings[?(@.id=='1')].entranceTime", contains("00:00")))
-                .andExpect(jsonPath("$.meetings[?(@.id=='1')].closingTime", contains("00:00")))
-                .andExpect(jsonPath("$.meetings[?(@.id=='1')].tardyCount", contains(1)))
-                .andExpect(jsonPath("$.meetings[?(@.id=='1')].isMaster", contains(true)))
-                .andExpect(jsonPath("$.meetings[?(@.id=='1')].isCoffeeTime", contains(false)))
-                .andExpect(jsonPath("$.meetings[?(@.id=='1')].hasUpcomingEvent", contains(false)))
-                // 일정이 있는 모임
-                .andExpect(jsonPath("$.meetings[?(@.id=='2')].name", contains("모임2")))
-                .andExpect(jsonPath("$.meetings[?(@.id=='2')].isActive", contains(true)))
-                .andExpect(jsonPath("$.meetings[?(@.id=='2')].entranceTime", contains("09:00")))
-                .andExpect(jsonPath("$.meetings[?(@.id=='2')].closingTime", contains("09:05")))
-                .andExpect(jsonPath("$.meetings[?(@.id=='2')].tardyCount", contains(2)))
-                .andExpect(jsonPath("$.meetings[?(@.id=='2')].isMaster", contains(true)))
-                .andExpect(jsonPath("$.meetings[?(@.id=='2')].isCoffeeTime", contains(false)))
-                .andExpect(jsonPath("$.meetings[?(@.id=='2')].hasUpcomingEvent", contains(true)))
+                .andExpect(jsonPath("$.meetings[*].id", containsInAnyOrder(1)))
+                .andExpect(jsonPath("$.meetings[*].name", contains("모임1")))
+                .andExpect(jsonPath("$.meetings[*].tardyCount", contains(1)))
+                .andExpect(jsonPath("$.meetings[*].isLoginUserMaster", contains(true)))
+                .andExpect(jsonPath("$.meetings[*].isCoffeeTime", contains(false)))
+                .andExpect(jsonPath("$.meetings[*].isActive", contains(false)))
+                .andExpect(jsonPath("$.meetings[*].upcomingEvent.id", contains(1)))
+                .andExpect(jsonPath("$.meetings[*].upcomingEvent.attendanceOpenTime", contains("09:30")))
+                .andExpect(jsonPath("$.meetings[*].upcomingEvent.attendanceClosedTime", contains("10:05")))
+                .andExpect(jsonPath("$.meetings[*].upcomingEvent.meetingStartTime", contains("10:00")))
+                .andExpect(jsonPath("$.meetings[*].upcomingEvent.meetingEndTime", contains("18:00")))
+                .andExpect(jsonPath("$.meetings[*].upcomingEvent.date", contains("2022-08-01")))
                 .andDo(document("meeting/find-my-meetings",
                         responseFields(
                                 fieldWithPath("meetings[].id").type(JsonFieldType.NUMBER).description(1L),
                                 fieldWithPath("meetings[].name").type(JsonFieldType.STRING).description("모임1"),
-                                fieldWithPath("meetings[].isActive").type(JsonFieldType.BOOLEAN).description(true),
-                                fieldWithPath("meetings[].entranceTime").type(JsonFieldType.STRING)
-                                        .description("09:00"),
-                                fieldWithPath("meetings[].closingTime").type(JsonFieldType.STRING)
-                                        .description("09:05"),
                                 fieldWithPath("meetings[].tardyCount").type(JsonFieldType.NUMBER)
                                         .description(1),
-                                fieldWithPath("meetings[].isMaster").type(JsonFieldType.BOOLEAN)
+                                fieldWithPath("meetings[].isLoginUserMaster").type(JsonFieldType.BOOLEAN)
                                         .description(true),
                                 fieldWithPath("meetings[].isCoffeeTime").type(JsonFieldType.BOOLEAN)
                                         .description(false),
-                                fieldWithPath("meetings[].hasUpcomingEvent").type(JsonFieldType.BOOLEAN)
-                                        .description(true)
+                                fieldWithPath("meetings[].isActive").type(JsonFieldType.BOOLEAN).description(true),
+                                fieldWithPath("meetings[].upcomingEvent.id").type(JsonFieldType.NUMBER)
+                                        .description(1),
+                                fieldWithPath("meetings[].upcomingEvent.attendanceOpenTime").type(JsonFieldType.STRING)
+                                        .description("09:30"),
+                                fieldWithPath("meetings[].upcomingEvent.attendanceClosedTime").type(
+                                                JsonFieldType.STRING)
+                                        .description("10:05"),
+                                fieldWithPath("meetings[].upcomingEvent.meetingStartTime").type(JsonFieldType.STRING)
+                                        .description("10:00"),
+                                fieldWithPath("meetings[].upcomingEvent.meetingEndTime").type(JsonFieldType.STRING)
+                                        .description("18:00"),
+                                fieldWithPath("meetings[].upcomingEvent.date").type(JsonFieldType.STRING)
+                                        .description("2022-08-01")
                         )
                 ));
+    }
+
+    @DisplayName("유저가 소속된 모든 미팅 방을 조회한다(다가오는 일정이 없으면 null 반환).")
+    @Test
+    void findAllByUserId_noUpcomingEvent() throws Exception {
+        // given
+        final MyMeetingResponse myMeetingResponse =
+                new MyMeetingResponse(1L, "모임1", 2, true, false, true,
+                        null);
+
+        final MyMeetingsResponse meetingsResponse =
+                new MyMeetingsResponse(List.of(myMeetingResponse));
+
+        validateToken("1");
+
+        // when
+        given(meetingService.findAllByUserId(eq(1L)))
+                .willReturn(meetingsResponse);
+
+        // then
+        performGet("/meetings/me")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.meetings[*].id", containsInAnyOrder(1)))
+                // 더 이상 일정이 없는 모임
+                .andExpect(jsonPath("$.meetings[*].name", contains("모임1")))
+                .andExpect(jsonPath("$.meetings[*].tardyCount", contains(2)))
+                .andExpect(jsonPath("$.meetings[*].isLoginUserMaster", contains(true)))
+                .andExpect(jsonPath("$.meetings[*].isCoffeeTime", contains(false)))
+                .andExpect(jsonPath("$.meetings[*].isActive", contains(true)))
+                .andExpect(jsonPath("$.meetings[*].upcomingEvent", contains(nullValue())));
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/repository/EventRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/repository/EventRepositoryTest.java
@@ -82,18 +82,18 @@ public class EventRepositoryTest {
     void findFirstByMeetingIdAndDateGreaterThanEqualOrderByDate(final int month, final int day,
                                                                 final int expectedMonth, final int expectedDay) {
         // given
-        final LocalTime enteranceTime = LocalTime.of(10, 0);
-        final LocalTime leaveTime = LocalTime.of(18, 0);
+        final LocalTime meetingStartTime = LocalTime.of(10, 0);
+        final LocalTime meetingEndTime = LocalTime.of(18, 0);
         final Meeting meeting = new Meeting("모임1");
 
         final Meeting savedMeeting = meetingRepository.save(meeting);
 
         final Event event1 = new Event(
-                LocalDate.of(2022, 8, 3), enteranceTime, leaveTime, savedMeeting);
+                LocalDate.of(2022, 8, 3), meetingStartTime, meetingEndTime, savedMeeting);
         final Event event2 = new Event(
-                LocalDate.of(2022, 8, 4), enteranceTime, leaveTime, savedMeeting);
+                LocalDate.of(2022, 8, 4), meetingStartTime, meetingEndTime, savedMeeting);
         final Event event3 = new Event(
-                LocalDate.of(2022, 8, 5), enteranceTime, leaveTime, savedMeeting);
+                LocalDate.of(2022, 8, 5), meetingStartTime, meetingEndTime, savedMeeting);
         eventRepository.save(event1);
         eventRepository.save(event2);
         eventRepository.save(event3);
@@ -112,18 +112,18 @@ public class EventRepositoryTest {
     @Test
     void findByMeetingIdAndDate() {
         // given
-        final LocalTime enteranceTime = LocalTime.of(10, 0);
-        final LocalTime leaveTime = LocalTime.of(18, 0);
+        final LocalTime meetingStartTime = LocalTime.of(10, 0);
+        final LocalTime meetingEndTime = LocalTime.of(18, 0);
         final Meeting meeting = new Meeting("모임1");
 
         final Meeting savedMeeting = meetingRepository.save(meeting);
 
         final Event event1 = new Event(
-                LocalDate.of(2022, 8, 3), enteranceTime, leaveTime, savedMeeting);
+                LocalDate.of(2022, 8, 3), meetingStartTime, meetingEndTime, savedMeeting);
         final Event event2 = new Event(
-                LocalDate.of(2022, 8, 4), enteranceTime, leaveTime, savedMeeting);
+                LocalDate.of(2022, 8, 4), meetingStartTime, meetingEndTime, savedMeeting);
         final Event event3 = new Event(
-                LocalDate.of(2022, 8, 5), enteranceTime, leaveTime, savedMeeting);
+                LocalDate.of(2022, 8, 5), meetingStartTime, meetingEndTime, savedMeeting);
         eventRepository.save(event1);
         eventRepository.save(event2);
         eventRepository.save(event3);

--- a/backend/src/test/java/com/woowacourse/moragora/service/AttendanceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/AttendanceServiceTest.java
@@ -223,8 +223,8 @@ class AttendanceServiceTest {
         serverTimeManager.refresh(dateTime);
 
         final EventRequest eventRequest = EventRequest.builder()
-                .entranceTime(event.getStartTime())
-                .leaveTime(event.getEndTime())
+                .meetingStartTime(event.getStartTime())
+                .meetingEndTime(event.getEndTime())
                 .date(event.getDate()).build();
 
         eventService.save(new EventsRequest(List.of(eventRequest)), meeting.getId());

--- a/backend/src/test/java/com/woowacourse/moragora/service/AttendanceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/AttendanceServiceTest.java
@@ -27,8 +27,8 @@ import com.woowacourse.moragora.entity.Status;
 import com.woowacourse.moragora.entity.user.User;
 import com.woowacourse.moragora.exception.ClientRuntimeException;
 import com.woowacourse.moragora.exception.event.EventNotFoundException;
-import com.woowacourse.moragora.exception.meeting.NotCheckInTimeException;
 import com.woowacourse.moragora.exception.meeting.MeetingNotFoundException;
+import com.woowacourse.moragora.exception.meeting.NotCheckInTimeException;
 import com.woowacourse.moragora.exception.participant.ParticipantNotFoundException;
 import com.woowacourse.moragora.support.DataSupport;
 import com.woowacourse.moragora.support.DatabaseCleanUp;
@@ -223,8 +223,8 @@ class AttendanceServiceTest {
         serverTimeManager.refresh(dateTime);
 
         final EventRequest eventRequest = EventRequest.builder()
-                .entranceTime(event.getEntranceTime())
-                .leaveTime(event.getLeaveTime())
+                .entranceTime(event.getStartTime())
+                .leaveTime(event.getEndTime())
                 .date(event.getDate()).build();
 
         eventService.save(new EventsRequest(List.of(eventRequest)), meeting.getId());

--- a/backend/src/test/java/com/woowacourse/moragora/service/EventServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/EventServiceTest.java
@@ -3,14 +3,21 @@ package com.woowacourse.moragora.service;
 import static com.woowacourse.moragora.support.EventFixtures.EVENT1;
 import static com.woowacourse.moragora.support.EventFixtures.EVENT2;
 import static com.woowacourse.moragora.support.MeetingFixtures.MORAGORA;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.moragora.dto.EventRequest;
+import com.woowacourse.moragora.dto.EventResponse;
 import com.woowacourse.moragora.dto.EventsRequest;
 import com.woowacourse.moragora.entity.Event;
 import com.woowacourse.moragora.entity.Meeting;
+import com.woowacourse.moragora.exception.event.EventNotFoundException;
 import com.woowacourse.moragora.support.DataSupport;
 import com.woowacourse.moragora.support.DatabaseCleanUp;
+import com.woowacourse.moragora.support.ServerTimeManager;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,6 +38,9 @@ class EventServiceTest {
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    private ServerTimeManager serverTimeManager;
 
     @BeforeEach
     void setUp() {
@@ -65,5 +75,49 @@ class EventServiceTest {
         // when, then
         assertThatCode(() -> eventService.save(eventsRequest, meeting.getId()))
                 .doesNotThrowAnyException();
+    }
+
+    @DisplayName("모임의 가장 가까운 일정을 조회한다.")
+    @Test
+    void findUpcomingEvent() {
+        // given
+        final Meeting meeting = dataSupport.saveMeeting(MORAGORA.create());
+
+        final Event event1 = EVENT1.create(meeting);
+        final Event event2 = EVENT2.create(meeting);
+        dataSupport.saveEvent(event1);
+        dataSupport.saveEvent(event2);
+
+        final LocalDateTime dateTime = LocalDateTime.of(2022, 7, 30, 10, 6);
+        serverTimeManager.refresh(dateTime);
+
+        final EventResponse expected = EventResponse.of(
+                event1, LocalTime.of(9, 30), LocalTime.of(10, 5));
+
+        // when
+        final EventResponse actual = eventService.findUpcomingEvent(meeting.getId());
+
+        // then
+        assertThat(actual).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @DisplayName("모임의 가장 가까운 일정을 조회했을 때, 다음 일정이 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void findUpcomingEvent_ifEventNotFound() {
+        // given
+        final Meeting meeting = dataSupport.saveMeeting(MORAGORA.create());
+
+        final Event event1 = EVENT1.create(meeting);
+        final Event event2 = EVENT2.create(meeting);
+        dataSupport.saveEvent(event1);
+        dataSupport.saveEvent(event2);
+
+        final LocalDateTime dateTime = LocalDateTime.of(2022, 8, 3, 10, 6);
+        serverTimeManager.refresh(dateTime);
+
+        // when, then
+        assertThatThrownBy(() -> eventService.findUpcomingEvent(meeting.getId()))
+                .isInstanceOf(EventNotFoundException.class);
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/service/EventServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/EventServiceTest.java
@@ -60,14 +60,14 @@ class EventServiceTest {
         final EventsRequest eventsRequest = new EventsRequest(
                 List.of(
                         EventRequest.builder()
-                                .entranceTime(event1.getStartTime())
-                                .leaveTime(event1.getEndTime())
+                                .meetingStartTime(event1.getStartTime())
+                                .meetingEndTime(event1.getEndTime())
                                 .date(event1.getDate())
                                 .build()
                         ,
                         EventRequest.builder()
-                                .entranceTime(event2.getStartTime())
-                                .leaveTime(event2.getEndTime())
+                                .meetingStartTime(event2.getStartTime())
+                                .meetingEndTime(event2.getEndTime())
                                 .date(event2.getDate())
                                 .build()
                 ));

--- a/backend/src/test/java/com/woowacourse/moragora/service/EventServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/EventServiceTest.java
@@ -60,14 +60,14 @@ class EventServiceTest {
         final EventsRequest eventsRequest = new EventsRequest(
                 List.of(
                         EventRequest.builder()
-                                .entranceTime(event1.getEntranceTime())
-                                .leaveTime(event1.getLeaveTime())
+                                .entranceTime(event1.getStartTime())
+                                .leaveTime(event1.getEndTime())
                                 .date(event1.getDate())
                                 .build()
                         ,
                         EventRequest.builder()
-                                .entranceTime(event2.getEntranceTime())
-                                .leaveTime(event2.getLeaveTime())
+                                .entranceTime(event2.getStartTime())
+                                .leaveTime(event2.getEndTime())
                                 .date(event2.getDate())
                                 .build()
                 ));

--- a/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
@@ -436,7 +436,7 @@ class MeetingServiceTest {
         final Event event1 = dataSupport.saveEvent(EVENT1.create(meeting1));
         final Event event2 = dataSupport.saveEvent(EVENT1.create(meeting1));
 
-        final LocalTime entranceTime = event1.getEntranceTime();
+        final LocalTime entranceTime = event1.getStartTime();
         final EventResponse upcomingEvent = EventResponse.of(event1, entranceTime.minusMinutes(30),
                 entranceTime.plusMinutes(5));
 

--- a/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/service/MeetingServiceTest.java
@@ -13,6 +13,7 @@ import static com.woowacourse.moragora.support.UserFixtures.createUsers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.moragora.dto.EventResponse;
 import com.woowacourse.moragora.dto.MeetingRequest;
 import com.woowacourse.moragora.dto.MeetingResponse;
 import com.woowacourse.moragora.dto.MyMeetingResponse;
@@ -29,6 +30,7 @@ import com.woowacourse.moragora.support.DataSupport;
 import com.woowacourse.moragora.support.DatabaseCleanUp;
 import com.woowacourse.moragora.support.ServerTimeManager;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -432,30 +434,30 @@ class MeetingServiceTest {
         dataSupport.saveParticipant(user, meeting1, true);
         dataSupport.saveParticipant(user, meeting2, true);
         final Event event1 = dataSupport.saveEvent(EVENT1.create(meeting1));
-        final Event event2 = dataSupport.saveEvent(EVENT1.create(meeting2));
+        final Event event2 = dataSupport.saveEvent(EVENT1.create(meeting1));
+
+        final LocalTime entranceTime = event1.getEntranceTime();
+        final EventResponse upcomingEvent = EventResponse.of(event1, entranceTime.minusMinutes(30),
+                entranceTime.plusMinutes(5));
 
         final MyMeetingResponse response1 = MyMeetingResponse.builder()
                 .id(meeting1.getId())
                 .name(meeting1.getName())
-                .isActive(false)
-                .entranceTime(event1.getEntranceTime())
-                .closingTime(event1.getEntranceTime().plusMinutes(5))
                 .tardyCount(0)
-                .isMaster(true)
+                .isLoginUserMaster(true)
                 .isCoffeeTime(false)
-                .hasUpcomingEvent(true)
+                .isActive(false)
+                .upcomingEvent(upcomingEvent)
                 .build();
 
         final MyMeetingResponse response2 = MyMeetingResponse.builder()
                 .id(meeting2.getId())
                 .name(meeting2.getName())
-                .isActive(false)
-                .entranceTime(event2.getEntranceTime())
-                .closingTime(event2.getEntranceTime().plusMinutes(5))
                 .tardyCount(0)
-                .isMaster(true)
+                .isLoginUserMaster(true)
                 .isCoffeeTime(false)
-                .hasUpcomingEvent(true)
+                .isActive(false)
+                .upcomingEvent(null)
                 .build();
 
         final LocalDateTime dateTime = LocalDateTime.of(2022, 8, 1, 10, 5);

--- a/backend/src/test/java/com/woowacourse/moragora/support/EventFixtures.java
+++ b/backend/src/test/java/com/woowacourse/moragora/support/EventFixtures.java
@@ -37,8 +37,8 @@ public enum EventFixtures {
     public Event create(final Meeting meeting) {
         return Event.builder()
                 .date(date)
-                .entranceTime(entranceTime)
-                .leaveTime(leaveTime)
+                .startTime(entranceTime)
+                .endTime(leaveTime)
                 .meeting(meeting)
                 .build();
     }


### PR DESCRIPTION
<!--Close #issue_number를 작성한다.-->
Close #294 
Close #304 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [X] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/show-upcoming-event -> dev

## 요구사항
<!--로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
- 모임에 설정된 이벤트 중 가장 가까운 날짜의 이벤트 조회 구현
- 모임 목록 조회 필드 수정 및 가까운 일정 정보 필드 추가
- 테스트 코드 작성

## 변경사항

## [Optional] 논의하고 싶은 내용
response Dto 필드들을 renaming하면서 Event Entity 필드도 rename할까 했으나
- Entity 필드도 rename 해야할 지
    - 한다면 DB 필드명도 함께 따라가는지
    - 한다면 `meetingStartTime`, `meetingEndTime`으로 하는지 아니면 `startTime`, `endTime`으로 하는지

등 추가적인 논의가 필요할 것 같아 일단은 Dto만 renaming 했습니다!
