### PR TITLE
[FE] 스토리북 preview padding 제거

### DIFF
--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -39,4 +39,5 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  layout: 'fullscreen',
 };


### PR DESCRIPTION
Close #352 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/fe/remove-storybook-padding -> dev

## 요구사항
- [x] 스토리북 preview의 padding을 제거한다.

## 변경사항
- 스토리북 `preview.js`에 `layout` 파라미터를 `fullscreen`으로 설정

## [Optional] 논의하고 싶은 내용
