### PR TITLE
[FE] 모임 페이지 하위에 마스터 및 일반 참가자 모임 설정 페이지 구현

### DIFF
--- a/frontend/cypress/e2e/app.cy.ts
+++ b/frontend/cypress/e2e/app.cy.ts
@@ -85,7 +85,7 @@ describe('모임', () => {
       member: ['user1', 'user2'],
     };
 
-    it('성공 시 일정 설정 페이지로 이동한다.', () => {
+    it('성공 시 생성된 모임 페이지로 이동한다.', () => {
       cy.get('a[class*="-RegisterLink"]').should('exist').click();
       cy.get('input[name="email"]').type(newUser.email);
       cy.get('button[class*="-EmailCheckButton"]').click();
@@ -100,7 +100,7 @@ describe('모임', () => {
       cy.get('input[name="searchMember"]').type(newMeeting.member[1]);
       cy.get('ul[class*="-QueryResultList"] > li').first().click();
       cy.get('button[class*="-MeetingCreateButton"]').click();
-      cy.url().should('include', '/config');
+      cy.url().should('include', 'meeting/8/coffee-stack');
     });
   });
 });

--- a/frontend/src/apis/meetingApis.ts
+++ b/frontend/src/apis/meetingApis.ts
@@ -1,5 +1,8 @@
 import {
+  Meeting,
   MeetingListResponseBody,
+  MeetingMasterAssignRequestBody,
+  MeetingNameUpdateRequestBody,
   MeetingResponseBody,
 } from 'types/meetingType';
 import { User } from 'types/userType';
@@ -83,3 +86,47 @@ export const postEmptyCoffeeStackApi = ({
     },
   });
 };
+
+export const updateMeetingNameApi =
+  (meetingId: string, accessToken: User['accessToken']) =>
+  (payload: MeetingNameUpdateRequestBody) =>
+    request(`/meetings/${meetingId}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+export const assignMasterApi =
+  (meetingId: number, accessToken: User['accessToken']) =>
+  (payload: MeetingMasterAssignRequestBody) =>
+    request(`/meetings/${meetingId}/me`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+export const deleteMeetingApi =
+  (meetingId: string, accessToken: User['accessToken']) => () =>
+    request<{}>(`/meetings/${meetingId}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+export const leaveMeetingApi =
+  (meetingId: string, accessToken: User['accessToken']) => () =>
+    request<{}>(`/meetings/${meetingId}/me`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });

--- a/frontend/src/components/CoffeeStackModal/CoffeeStackModal.styled.ts
+++ b/frontend/src/components/CoffeeStackModal/CoffeeStackModal.styled.ts
@@ -22,7 +22,7 @@ export const StatsBox = styled.div`
   overflow: scroll;
 `;
 
-export const Header = styled.h1`
+export const Header = styled.h2`
   font-size: 1.5rem;
 `;
 

--- a/frontend/src/mocks/fixtures/meetings.ts
+++ b/frontend/src/mocks/fixtures/meetings.ts
@@ -7,7 +7,7 @@ const meetings: (Meeting & { masterId: User['id'] })[] = [
     name: '리액트 사랑방',
     isActive: false,
     userIds: [1, 2, 3, 4, 5],
-    attendanceEventCount: 10,
+    attendedEventCount: 10,
     masterId: 1,
   },
   {
@@ -15,7 +15,7 @@ const meetings: (Meeting & { masterId: User['id'] })[] = [
     name: '우테코 레벨3 반상회',
     isActive: false,
     userIds: [1, 2, 3, 4, 5, 6],
-    attendanceEventCount: 10,
+    attendedEventCount: 10,
     masterId: 2,
   },
   {
@@ -23,7 +23,7 @@ const meetings: (Meeting & { masterId: User['id'] })[] = [
     name: '이게모임',
     isActive: false,
     userIds: [1, 3, 4, 5, 6, 7],
-    attendanceEventCount: 10,
+    attendedEventCount: 10,
     masterId: 3,
   },
   {
@@ -31,7 +31,7 @@ const meetings: (Meeting & { masterId: User['id'] })[] = [
     name: '2022 우아한테크코스 백엔드4기 비장의 토비의 스프링 스터디',
     isActive: false,
     userIds: [1, 4, 5, 6, 7, 8],
-    attendanceEventCount: 10,
+    attendedEventCount: 10,
     masterId: 4,
   },
   {
@@ -39,7 +39,7 @@ const meetings: (Meeting & { masterId: User['id'] })[] = [
     name: '저건모임',
     isActive: false,
     userIds: [1, 5, 6, 7, 8, 9],
-    attendanceEventCount: 10,
+    attendedEventCount: 10,
     masterId: 5,
   },
   {
@@ -47,7 +47,7 @@ const meetings: (Meeting & { masterId: User['id'] })[] = [
     name: '모임6',
     isActive: false,
     userIds: [1, 6, 7, 8, 9, 10],
-    attendanceEventCount: 10,
+    attendedEventCount: 10,
     masterId: 1,
   },
   {
@@ -55,7 +55,7 @@ const meetings: (Meeting & { masterId: User['id'] })[] = [
     name: '모임7',
     isActive: false,
     userIds: [1, 7, 8, 9, 10, 11],
-    attendanceEventCount: 10,
+    attendedEventCount: 10,
     masterId: 2,
   },
   {
@@ -63,7 +63,7 @@ const meetings: (Meeting & { masterId: User['id'] })[] = [
     name: '사단법인 싱겁게먹기실천연구회',
     isActive: false,
     userIds: [1, 8, 9, 10, 11, 12],
-    attendanceEventCount: 10,
+    attendedEventCount: 10,
     masterId: 3,
   },
 ];

--- a/frontend/src/mocks/handlers/meetingHandler.ts
+++ b/frontend/src/mocks/handlers/meetingHandler.ts
@@ -43,7 +43,7 @@ export default [
 
     const responseBody: MeetingListResponseBody = {
       meetings: myMeetings.map(
-        ({ attendanceEventCount, masterId, userIds, ...meeting }) => ({
+        ({ attendedEventCount, masterId, userIds, ...meeting }) => ({
           ...meeting,
           isLoginUserMaster: masterId === user.id,
           isCoffeeTime: true,
@@ -150,7 +150,7 @@ export default [
         ...meeting,
         id: meetingId,
         isActive: false,
-        attendanceEventCount: 0,
+        attendedEventCount: 0,
         masterId: token.id,
       });
 

--- a/frontend/src/pages/CalendarPage/index.tsx
+++ b/frontend/src/pages/CalendarPage/index.tsx
@@ -1,10 +1,5 @@
 import { useContext } from 'react';
-import {
-  Navigate,
-  useNavigate,
-  useOutletContext,
-  useParams,
-} from 'react-router-dom';
+import { Navigate, useOutletContext, useParams } from 'react-router-dom';
 import { css } from '@emotion/react';
 import * as S from './CalendarPage.styled';
 import Button from 'components/@shared/Button';

--- a/frontend/src/pages/CoffeeStackPage/index.tsx
+++ b/frontend/src/pages/CoffeeStackPage/index.tsx
@@ -114,7 +114,7 @@ const CoffeeStackPage = () => {
               <S.SectionTitle>커피 스택 현황</S.SectionTitle>
               <p>
                 총 출석일:{' '}
-                <span>{meetingQuery.data?.body.attendanceEventCount}</span>
+                <span>{meetingQuery.data?.body.attendedEventCount}</span>
               </p>
             </S.UserListSectionHeader>
             <S.UserListBox>

--- a/frontend/src/pages/MeetingConfigPage/MasterAssignSection/MasterAssignSection.stories.jsx
+++ b/frontend/src/pages/MeetingConfigPage/MasterAssignSection/MasterAssignSection.stories.jsx
@@ -1,0 +1,21 @@
+import { css } from '@emotion/react';
+import MasterAssignSection from '.';
+
+export default {
+  title: 'Components/MasterAssignSection',
+  component: MasterAssignSection,
+};
+
+function Template(args) {
+  return (
+    <div
+      css={css`
+        width: 100%;
+      `}
+    >
+      <MasterAssignSection {...args} />
+    </div>
+  );
+}
+
+export const Default = Template.bind({});

--- a/frontend/src/pages/MeetingConfigPage/MasterAssignSection/MasterAssignSection.styled.ts
+++ b/frontend/src/pages/MeetingConfigPage/MasterAssignSection/MasterAssignSection.styled.ts
@@ -1,0 +1,57 @@
+import styled from '@emotion/styled';
+
+export const Layout = styled.section``;
+
+export const Label = styled.label`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  overflow: hidden;
+`;
+
+export const MasterAssignBox = styled.div``;
+
+export const SelectBox = styled.div`
+  padding: 0.75rem 1.5rem;
+  border-radius: 1rem;
+  background-color: ${({ theme: { colors } }) => colors['white']};
+  display: flex;
+  gap: 0.5rem;
+`;
+
+export const SelectSpan = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: ${({ theme: { colors } }) => colors['primary']};
+  cursor: pointer;
+`;
+
+export const ParticipantList = styled.ul`
+  padding: 0;
+  list-style: none;
+  position: absolute;
+  width: 100%;
+  max-height: 12rem;
+  z-index: 10;
+
+  display: flex;
+  flex-direction: column;
+  margin-top: 0.25rem;
+
+  border-radius: 0.5rem;
+  background-color: ${({ theme: { colors } }) => colors['white']};
+  box-shadow: 0 0 1rem rgba(0, 0, 0, 0.1);
+
+  overflow: scroll;
+`;
+
+export const ParticipantListItem = styled.li`
+  padding: 0.5rem;
+
+  :hover {
+    cursor: pointer;
+    background-color: ${({ theme: { colors } }) => colors['surface']};
+  }
+`;

--- a/frontend/src/pages/MeetingConfigPage/MasterAssignSection/index.tsx
+++ b/frontend/src/pages/MeetingConfigPage/MasterAssignSection/index.tsx
@@ -1,0 +1,128 @@
+import { useContext, useState } from 'react';
+import * as S from './MasterAssignSection.styled';
+import Button from 'components/@shared/Button';
+import ModalPortal from 'components/ModalPortal';
+import ModalWindow from 'components/@shared/ModalWindow';
+import { Participant } from 'types/userType';
+import { useOutletContext } from 'react-router-dom';
+import { QueryState } from 'types/queryType';
+import { assignMasterApi, getMeetingData } from 'apis/meetingApis';
+import { getUpcomingEventApi } from 'apis/eventApis';
+import { ArrayElement } from 'types/utilityType';
+import { MeetingResponseBody } from 'types/meetingType';
+import request from 'utils/request';
+import useMutation from 'hooks/useMutation';
+import { userContext, UserContextValues } from 'contexts/userContext';
+
+type SelectedParticipant = ArrayElement<MeetingResponseBody['users']>;
+
+const MasterAssignSection = () => {
+  const { accessToken } = useContext(userContext) as UserContextValues;
+  const [isDropdownOpened, setIsDropdownOpened] = useState(false);
+  const [isModalOpened, setIsModalOpened] = useState(false);
+  const { meetingQuery } = useOutletContext<{
+    meetingQuery: QueryState<typeof getMeetingData>;
+    upcomingEventQuery: QueryState<typeof getUpcomingEventApi>;
+    totalTardyCount: number;
+    upcomingEventNotExist: boolean;
+  }>();
+  const participants = meetingQuery.data?.body.users;
+  const [selectedParticipant, setSelectedParticipant] =
+    useState<SelectedParticipant>();
+
+  const masterAssignMutation = useMutation(
+    assignMasterApi(meetingQuery.data?.body.id as number, accessToken),
+    {
+      onSuccess: () => {
+        meetingQuery.refetch();
+        alert('마스터 권한을 넘겼습니다.');
+      },
+      onError: (e) => {
+        alert(e.message);
+      },
+    }
+  );
+
+  const handleParticipantClick = (participant: SelectedParticipant) => () => {
+    setIsDropdownOpened(false);
+    setSelectedParticipant(participant);
+    setIsModalOpened(true);
+  };
+
+  const handleMasterAssignModalConfirm = () => {
+    if (selectedParticipant) {
+      masterAssignMutation.mutate({ userId: selectedParticipant.id });
+    }
+
+    setIsModalOpened(false);
+  };
+
+  const handleMasterAssignModalDismiss = () => {
+    setIsModalOpened(false);
+  };
+
+  return (
+    <>
+      {isModalOpened && (
+        <ModalPortal closePortal={() => setIsModalOpened(false)}>
+          <ModalWindow
+            message={`${
+              selectedParticipant?.nickname ?? '선택되지 않음'
+            }에게 마스터를 넘길까요?`}
+            onConfirm={handleMasterAssignModalConfirm}
+            onDismiss={handleMasterAssignModalDismiss}
+          />
+        </ModalPortal>
+      )}
+      <S.Label>
+        마스터 넘기기
+        <S.MasterAssignBox>
+          <S.SelectBox>
+            <S.SelectSpan
+              onClick={(e) => {
+                setIsDropdownOpened((prev) => !prev);
+              }}
+            >
+              {selectedParticipant?.nickname ?? '선택되지 않음'}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1rem"
+                height="1rem"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+            </S.SelectSpan>
+            에게 마스터 넘기기
+          </S.SelectBox>
+          {isDropdownOpened && (
+            <S.ParticipantList>
+              {participants
+                ?.filter(({ isMaster }) => !isMaster)
+                .map((participant) => (
+                  <S.ParticipantListItem
+                    key={participant.id}
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                    }}
+                    onClick={handleParticipantClick(participant)}
+                  >
+                    {participant.nickname}
+                  </S.ParticipantListItem>
+                ))}
+            </S.ParticipantList>
+          )}
+        </S.MasterAssignBox>
+      </S.Label>
+    </>
+  );
+};
+
+export default MasterAssignSection;

--- a/frontend/src/pages/MeetingConfigPage/MeetingConfigPage.styled.ts
+++ b/frontend/src/pages/MeetingConfigPage/MeetingConfigPage.styled.ts
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+
+export const Layout = styled.div`
+  /* padding: 0.75rem; */
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+export const Form = styled.form`
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+export const FieldBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+`;
+
+export const Label = styled.label`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  overflow: hidden;
+`;
+
+export const ButtonBox = styled.div`
+  padding: 0 0.75rem;
+`;

--- a/frontend/src/pages/MeetingConfigPage/index.tsx
+++ b/frontend/src/pages/MeetingConfigPage/index.tsx
@@ -1,0 +1,159 @@
+import React, { useContext, useState } from 'react';
+import {
+  Navigate,
+  useNavigate,
+  useOutletContext,
+  useParams,
+} from 'react-router-dom';
+import { css } from '@emotion/react';
+import * as S from './MeetingConfigPage.styled';
+import Button from 'components/@shared/Button';
+import Input from 'components/@shared/Input';
+import Spinner from 'components/@shared/Spinner';
+import ErrorIcon from 'components/@shared/ErrorIcon';
+import { userContext, UserContextValues } from 'contexts/userContext';
+import useForm from 'hooks/useForm';
+import useMutation from 'hooks/useMutation';
+import {
+  deleteMeetingApi,
+  getMeetingData,
+  updateMeetingNameApi,
+} from 'apis/meetingApis';
+import { getUpcomingEventApi } from 'apis/eventApis';
+import { QueryState } from 'types/queryType';
+import MasterAssignSection from './MasterAssignSection';
+import InputHint from 'components/@shared/InputHint';
+import { MeetingNameUpdateRequestBody } from 'types/meetingType';
+
+const MeetingConfigPage = () => {
+  const navigate = useNavigate();
+  const { id: meetingId } = useParams();
+  const { accessToken } = useContext(userContext) as UserContextValues;
+
+  if (!meetingId) {
+    return <Navigate to="/error" />;
+  }
+
+  const { errors, onSubmit, register } = useForm();
+  const { meetingQuery } = useOutletContext<{
+    meetingQuery: QueryState<typeof getMeetingData>;
+    upcomingEventQuery: QueryState<typeof getUpcomingEventApi>;
+    totalTardyCount: number;
+    upcomingEventNotExist: boolean;
+  }>();
+  const meetingNameUpdateMutation = useMutation(
+    updateMeetingNameApi(meetingId, accessToken),
+    {
+      onSuccess: () => {
+        meetingQuery.refetch();
+        alert('모임명이 수정되었습니다.');
+      },
+      onError: (e) => {
+        alert(e.message);
+      },
+    }
+  );
+  const meetingDeleteMutation = useMutation(
+    deleteMeetingApi(meetingId, accessToken),
+    {
+      onSuccess: () => {
+        alert('모임이 삭제되었습니다.');
+        navigate('/');
+      },
+      onError: (e) => {
+        alert(e.message);
+      },
+    }
+  );
+  const meetingLeaveMutation = useMutation(
+    deleteMeetingApi(meetingId, accessToken),
+    {
+      onSuccess: () => {
+        alert('모임을 나갔습니다.');
+        navigate('/');
+      },
+      onError: (e) => {
+        alert(e.message);
+      },
+    }
+  );
+
+  const handleMeetingNameSubmitValid: React.FormEventHandler<
+    HTMLFormElement
+  > = ({ currentTarget }) => {
+    const formData = new FormData(currentTarget);
+    const formDataObject = Object.fromEntries(
+      formData.entries()
+    ) as MeetingNameUpdateRequestBody;
+
+    meetingNameUpdateMutation.mutate(formDataObject);
+  };
+
+  const handleMeetingDeleteClick: React.MouseEventHandler<
+    HTMLButtonElement
+  > = ({ currentTarget }) => {
+    meetingDeleteMutation.mutate({});
+  };
+
+  const handleMeetingLeaveClick: React.MouseEventHandler<HTMLButtonElement> = ({
+    currentTarget,
+  }) => {
+    meetingLeaveMutation.mutate({});
+  };
+
+  if (meetingQuery.data?.body.isLoginUserMaster) {
+    return (
+      <S.Layout>
+        <S.Form
+          id="meeting-name-update-form"
+          {...onSubmit(handleMeetingNameSubmitValid)}
+        >
+          <S.FieldBox>
+            <S.Label>
+              모임명
+              <Input
+                type="text"
+                {...register('name', {
+                  defaultValue: meetingQuery.data.body.name,
+                  placeholder: meetingQuery.data.body.name,
+                  maxLength: 50,
+                  required: true,
+                })}
+              />
+            </S.Label>
+            <InputHint isShow={!!errors['name']} message={errors['name']} />
+          </S.FieldBox>
+          <Button form="meeting-name-update-form">모임명 변경하기</Button>
+        </S.Form>
+        <div
+          css={css`
+            padding: 0.75rem;
+          `}
+        >
+          <MasterAssignSection />
+        </div>
+        <div
+          css={css`
+            padding: 0.75rem;
+          `}
+        >
+          <Button onClick={handleMeetingDeleteClick}>모임 삭제하기</Button>
+        </div>
+      </S.Layout>
+    );
+  }
+
+  return (
+    <S.Layout>
+      <div
+        css={css`
+          padding: 0.75rem;
+        `}
+      >
+        <Button onClick={handleMeetingLeaveClick}>모임 나가기</Button>
+      </div>
+    </S.Layout>
+  );
+};
+
+export default MeetingConfigPage;

--- a/frontend/src/pages/MeetingCreatePage/index.tsx
+++ b/frontend/src/pages/MeetingCreatePage/index.tsx
@@ -35,7 +35,7 @@ const MeetingCreatePage = () => {
   const meetingCreateMutation = useMutation(createMeetingApi, {
     onSuccess: ({ body: { id } }) => {
       alert('모임 생성을 완료했습니다.');
-      navigate(`/meeting/${id}/config`);
+      navigate(`/meeting/${id}`);
     },
     onError: () => {
       alert('모임 생성을 실패했습니다.');

--- a/frontend/src/pages/MeetingDetailPage/MeetingDetailPage.styled.ts
+++ b/frontend/src/pages/MeetingDetailPage/MeetingDetailPage.styled.ts
@@ -48,6 +48,8 @@ export const TabNavLink = styled(NavLink)`
   color: ${({ theme: { colors } }) => colors['subtle-light']};
   z-index: 1;
 
+  transition: all 300ms ease-out;
+
   &.active {
     color: ${({ theme: { colors } }) => colors['black']};
   }
@@ -73,7 +75,7 @@ export const IndicatorBox = styled.div<{ tabPositions: TabPosition[] }>`
   display: flex;
   justify-content: center;
 
-  transition: all 300ms linear;
+  transition: all 300ms ease-out;
 
   ${({ tabPositions }) => setTabPosition(tabPositions)}
 `;

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -7,12 +7,12 @@ import LoginPage from 'pages/LoginPage';
 import Auth from './Auth';
 import SettingsPage from 'pages/SettingsPage';
 import NotFoundPage from 'pages/NotFoundPage';
-import EventCreatePage from 'pages/EventCreatePage';
 import MeetingDetailPage from 'pages/MeetingDetailPage';
 import UserConfigPage from 'pages/UserConfigPage';
 import PasswordUpdatePage from 'pages/PasswordUpdatePage';
 import UnregisterPage from 'pages/UnregisterPage';
 import CalendarPage from 'pages/CalendarPage';
+import MeetingConfigPage from 'pages/MeetingConfigPage';
 
 const Router = () => {
   return useRoutes([
@@ -38,7 +38,7 @@ const Router = () => {
                 { path: '', element: <Navigate to="coffee-stack" replace /> },
                 { path: 'coffee-stack', element: <CoffeeStackPage /> },
                 { path: 'calendar', element: <CalendarPage /> },
-                { path: 'config', element: <div>config</div> },
+                { path: 'config', element: <MeetingConfigPage /> },
                 { path: '*', element: <NotFoundPage /> },
               ],
             },

--- a/frontend/src/types/meetingType.ts
+++ b/frontend/src/types/meetingType.ts
@@ -6,7 +6,7 @@ export type Meeting = {
   name: string;
   isActive: boolean;
   userIds: number[];
-  attendanceEventCount: number;
+  attendedEventCount: number;
 };
 
 export type MeetingWithTardyCount = {
@@ -40,7 +40,7 @@ export type MeetingListResponseBody = {
 export type MeetingResponseBody = {
   id: number;
   name: string;
-  attendanceEventCount: number;
+  attendedEventCount: number;
   isActive: boolean;
   isLoginUserMaster: boolean;
   isCoffeeTime: boolean;
@@ -49,4 +49,8 @@ export type MeetingResponseBody = {
 
 export type MeetingMasterAssignRequestBody = {
   userId: User['id'];
+};
+
+export type MeetingNameUpdateRequestBody = {
+  name: Meeting['name'];
 };


### PR DESCRIPTION
Close #312 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/fe/meeting-config-page -> dev

## 요구사항
- [x] 일반 참가자는 모임을 나갈 수 있다.
- [x] 마스터는 모임 정보를 수정할 수 있다.
- [x] 마스터는 모임 마스터 권한을 양도할 수 있다.
- [x] 마스터는 모임을 삭제할 수 있다.

## 변경사항
- MeetingConfigPage 추가

## [Optional] 논의하고 싶은 내용

