### PR TITLE
[BE] 소나큐브 서브모듈토큰 에러 

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -28,13 +28,6 @@ jobs:
       SONARQUBE_URL: ${{ secrets.SONAR_HOST_URL }}
       SONARQUBE_TOKEN : ${{ secrets.SONAR_TOKEN }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
-#      TOKEN_KEY: ${{ secrets.TOKEN_KEY }}
-#      TOKEN_EXPIRE_LENGTH: ${{ secrets.TOKEN_EXPIRE_LENGTH }}
-#      GOOGLE_CLENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-#      GOOGLE_CLENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-#      GOOGLE_GRANT_TYPE: ${{ secrets.GOOGLE_GRANT_TYPE }}
-#      GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
-      
       
     steps:
       - name: Checkout source code
@@ -52,12 +45,6 @@ jobs:
           -Dsonar.projectKey=${{ env.SONARQUBE_PROJECT_KEY }}
           -Dsonar.projectName=${{ env.SONARQUBE_PROJECT_KEY }}-${{ env.PR_NUMBER }}
           -Dsonar.login=${{ env.SONARQUBE_TOKEN }}
-#          -Dsecurity.jwt.token.secret-key=${{ env.TOKEN_KEY }}
-#          -Dsecurity.jwt.token.expire-length=${{ env.EXPIRE_LENGTH }}
-#          -Doauth2.google.client-id=${{ env.GOOGLE_CIENT_ID }}
-#          -Doauth2.google.client-secret=${{ env.GOOGLE_CLIENT_SECRET }}
-#          -Doauth2.google.grant-type=${{ env.GOOGLE_GRANT_TYPE }}
-#          -Doauth2.google.redirect-uri=${{ env.GOOGLE_REDIRECT_URI }}
         
       - name: Comment Sonarqube URL
         uses: actions/github-script@v4

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.SUBMODULE_TOKEN }}
+          submodules: recursive
 
   analysis:
     runs-on: ubuntu-latest
@@ -25,17 +28,20 @@ jobs:
       SONARQUBE_URL: ${{ secrets.SONAR_HOST_URL }}
       SONARQUBE_TOKEN : ${{ secrets.SONAR_TOKEN }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
-      TOKEN_KEY: ${{ secrets.TOKEN_KEY }}
-      TOKEN_EXPIRE_LENGTH: ${{ secrets.TOKEN_EXPIRE_LENGTH }}
-      GOOGLE_CLENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-      GOOGLE_CLENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-      GOOGLE_GRANT_TYPE: ${{ secrets.GOOGLE_GRANT_TYPE }}
-      GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
+#      TOKEN_KEY: ${{ secrets.TOKEN_KEY }}
+#      TOKEN_EXPIRE_LENGTH: ${{ secrets.TOKEN_EXPIRE_LENGTH }}
+#      GOOGLE_CLENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+#      GOOGLE_CLENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+#      GOOGLE_GRANT_TYPE: ${{ secrets.GOOGLE_GRANT_TYPE }}
+#      GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
       
       
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.SUBMODULE_TOKEN }}
+          submodules: recursive
         
       - name: gradlew permission change
         run: sudo chmod 755 gradlew
@@ -46,12 +52,12 @@ jobs:
           -Dsonar.projectKey=${{ env.SONARQUBE_PROJECT_KEY }}
           -Dsonar.projectName=${{ env.SONARQUBE_PROJECT_KEY }}-${{ env.PR_NUMBER }}
           -Dsonar.login=${{ env.SONARQUBE_TOKEN }}
-          -Dsecurity.jwt.token.secret-key=${{ env.TOKEN_KEY }}
-          -Dsecurity.jwt.token.expire-length=${{ env.EXPIRE_LENGTH }}
-          -Doauth2.google.client-id=${{ env.GOOGLE_CIENT_ID }}
-          -Doauth2.google.client-secret=${{ env.GOOGLE_CLIENT_SECRET }}
-          -Doauth2.google.grant-type=${{ env.GOOGLE_GRANT_TYPE }}
-          -Doauth2.google.redirect-uri=${{ env.GOOGLE_REDIRECT_URI }}
+#          -Dsecurity.jwt.token.secret-key=${{ env.TOKEN_KEY }}
+#          -Dsecurity.jwt.token.expire-length=${{ env.EXPIRE_LENGTH }}
+#          -Doauth2.google.client-id=${{ env.GOOGLE_CIENT_ID }}
+#          -Doauth2.google.client-secret=${{ env.GOOGLE_CLIENT_SECRET }}
+#          -Doauth2.google.grant-type=${{ env.GOOGLE_GRANT_TYPE }}
+#          -Doauth2.google.redirect-uri=${{ env.GOOGLE_REDIRECT_URI }}
         
       - name: Comment Sonarqube URL
         uses: actions/github-script@v4

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -17,9 +17,6 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.SUBMODULE_TOKEN }}
-          submodules: true
 
   analysis:
     runs-on: ubuntu-latest
@@ -28,15 +25,18 @@ jobs:
       SONARQUBE_URL: ${{ secrets.SONAR_HOST_URL }}
       SONARQUBE_TOKEN : ${{ secrets.SONAR_TOKEN }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
+      TOKEN_KEY: ${{ secrets.TOKEN_KEY }}
+      TOKEN_EXPIRE_LENGTH: ${{ secrets.TOKEN_EXPIRE_LENGTH }}
+      GOOGLE_CLENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+      GOOGLE_CLENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+      GOOGLE_GRANT_TYPE: ${{ secrets.GOOGLE_GRANT_TYPE }}
+      GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
       
       
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.SUBMODULE_TOKEN }}
-          submodules: true
-
+        
       - name: gradlew permission change
         run: sudo chmod 755 gradlew
 
@@ -46,6 +46,12 @@ jobs:
           -Dsonar.projectKey=${{ env.SONARQUBE_PROJECT_KEY }}
           -Dsonar.projectName=${{ env.SONARQUBE_PROJECT_KEY }}-${{ env.PR_NUMBER }}
           -Dsonar.login=${{ env.SONARQUBE_TOKEN }}
+          -Dsecurity.jwt.token.secret-key=${{ env.TOKEN_KEY }}
+          -Dsecurity.jwt.token.expire-length=${{ env.EXPIRE_LENGTH }}
+          -Doauth2.google.client-id=${{ env.GOOGLE_CIENT_ID }}
+          -Doauth2.google.client-secret=${{ env.GOOGLE_CLIENT_SECRET }}
+          -Doauth2.google.grant-type=${{ env.GOOGLE_GRANT_TYPE }}
+          -Doauth2.google.redirect-uri=${{ env.GOOGLE_REDIRECT_URI }}
         
       - name: Comment Sonarqube URL
         uses: actions/github-script@v4


### PR DESCRIPTION
Close #386 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
fix/be/sonarqube-with-submodule -> dev

## 요구사항
소나큐브 workflow에서 서브모듈 토큰을 못 읽는 문제를 해결한다.
