### PR TITLE
[FE] Auth 시 메인 페이지로 리다이렉션되는 버그 수정

### DIFF
--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -1,8 +1,6 @@
 import { defineConfig } from 'cypress';
 const webpackConfig = require('./webpack/webpack.test');
 
-console.log(webpackConfig);
-
 export default defineConfig({
   reporter: 'junit',
   reporterOptions: {

--- a/frontend/src/router/Auth.tsx
+++ b/frontend/src/router/Auth.tsx
@@ -9,11 +9,11 @@ const Auth: React.FC<AuthProps> = ({ shouldLogin }) => {
   const userState = useContext(userContext);
 
   useEffect(() => {
-    if (shouldLogin && !userState?.user?.accessToken) {
+    if (shouldLogin && !userState?.accessToken) {
       navigate('/login');
     }
 
-    if (!shouldLogin && userState?.user?.accessToken) {
+    if (!shouldLogin && userState?.accessToken) {
       navigate('/');
     }
   }, [navigate, userState]);


### PR DESCRIPTION
Close #417 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/fe/fix-auth -> dev

## 요구사항
로그인한 상태에서 url을 주소창에 입력하여 접속 시 해당 페이지가 보여진다.

## 변경사항
- https://github.com/woowacourse-teams/2022-moragora/issues/417#issuecomment-1247605342
- 불필요한 `console.log 제거`

## [Optional] 논의하고 싶은 내용

