### PR TITLE
[BE] jacoco 테스트 커버리지 기준 설정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -18,6 +18,7 @@ ext {
 test {
     outputs.dir snippetsDir
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
 }
 
 asciidoctor {
@@ -89,7 +90,6 @@ bootJar {
 
 tasks.named('test') {
     useJUnitPlatform()
-    finalizedBy 'jacocoTestReport'
 }
 
 jacoco {
@@ -100,7 +100,38 @@ jacocoTestReport {
     reports {
         xml.enabled true
         csv.enabled false
-        html.enabled false
+        html.enabled true
+    }
+
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'INSTRUCTION'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            excludes = ['*support*', '*config*', '*dto*', '*exception*', '*logging*', '*Application*']
+        }
     }
 }
 

--- a/backend/lombok.config
+++ b/backend/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치

feature/be/jacoco -> dev

## 요구사항

- jacoco를 이용해서 최소 테스트 커버리지 기준을 설정했습니다.

## 논의하고 싶은 내용

현재로서는 80%를 기준으로 설정을 해놓았는데 엔티티 클래스들이 80%를 넘기지 못하고 있어요.. equals & hashCode 같은 메서드 때문에요! 
새로 추가한 lombok.config에 적용한 설정을 해놓으면 롬복으로 만든 메서드들 (@getter, @builder) 은 jacoco 커버리지에서 제외되게 되는데요! equals & hashcode들을 롬복으로 적용하는 것은 어떻게 생각하신지? 아니면 커버리지 기준을 조금 낮춰도 될것같아요! 