### PR TITLE
[BE] 누락된 엔티티 단위 테스트 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/moragora/entity/Attendance.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/Attendance.java
@@ -1,6 +1,5 @@
 package com.woowacourse.moragora.entity;
 
-import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -12,6 +11,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,6 +19,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "attendance")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@EqualsAndHashCode(of = "id")
 public class Attendance {
 
     @Id
@@ -67,22 +68,5 @@ public class Attendance {
 
     public boolean isEnabled() {
         return !disabled;
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof Attendance)) {
-            return false;
-        }
-        final Attendance that = (Attendance) o;
-        return Objects.equals(id, that.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id);
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/entity/Attendance.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/Attendance.java
@@ -12,6 +12,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.EqualsAndHashCode.Include;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,11 +20,12 @@ import lombok.NoArgsConstructor;
 @Table(name = "attendance")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@EqualsAndHashCode(of = "id")
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Attendance {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Include
     private Long id;
 
     @Enumerated(EnumType.STRING)

--- a/backend/src/main/java/com/woowacourse/moragora/entity/Meeting.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/Meeting.java
@@ -15,6 +15,7 @@ import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.EqualsAndHashCode.Include;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,13 +23,14 @@ import lombok.NoArgsConstructor;
 @Table(name = "meeting")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@EqualsAndHashCode(of = "id")
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Meeting {
 
     private static final int MAX_NAME_LENGTH = 50;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Include
     private Long id;
 
     @Column(nullable = false)
@@ -38,9 +40,14 @@ public class Meeting {
     private final List<Participant> participants = new ArrayList<>();
 
     @Builder
-    public Meeting(final String name) {
+    public Meeting(final Long id, final String name) {
         validateName(name);
+        this.id = id;
         this.name = name;
+    }
+
+    public Meeting(final String name) {
+        this(null, name);
     }
 
     public void updateName(final String name) {

--- a/backend/src/main/java/com/woowacourse/moragora/entity/Meeting.java
+++ b/backend/src/main/java/com/woowacourse/moragora/entity/Meeting.java
@@ -3,7 +3,6 @@ package com.woowacourse.moragora.entity;
 import com.woowacourse.moragora.exception.InvalidFormatException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -15,6 +14,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,6 +22,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "meeting")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@EqualsAndHashCode(of = "id")
 public class Meeting {
 
     private static final int MAX_NAME_LENGTH = 50;
@@ -57,22 +58,5 @@ public class Meeting {
         if (name.length() > MAX_NAME_LENGTH) {
             throw new InvalidFormatException();
         }
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof Meeting)) {
-            return false;
-        }
-        final Meeting meeting = (Meeting) o;
-        return Objects.equals(this.id, meeting.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.id);
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/entity/AttendanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/entity/AttendanceTest.java
@@ -1,0 +1,89 @@
+package com.woowacourse.moragora.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.moragora.entity.user.User;
+import com.woowacourse.moragora.support.EventFixtures;
+import com.woowacourse.moragora.support.MeetingFixtures;
+import com.woowacourse.moragora.support.UserFixtures;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AttendanceTest {
+
+    @DisplayName("Attendance 상태가 변경되는지 확인한다.")
+    @Test
+    void changeAttendanceStatus() {
+        // given
+        final User user = UserFixtures.KUN.create();
+        final Meeting meeting = MeetingFixtures.MORAGORA.create();
+        final Event event = EventFixtures.EVENT1.create(meeting);
+        final Participant participant = new Participant(user, meeting, false);
+        final Attendance attendance = new Attendance(Status.NONE, false, participant, event);
+
+        // when
+        attendance.changeAttendanceStatus(Status.TARDY);
+
+        // then
+        assertThat(attendance.getStatus()).isEqualTo(Status.TARDY);
+    }
+
+    @DisplayName("Attendance가 비활성화 되는지 확인한다.")
+    @Test
+    void disable() {
+        // given
+        final User user = UserFixtures.KUN.create();
+        final Meeting meeting = MeetingFixtures.MORAGORA.create();
+        final Event event = EventFixtures.EVENT1.create(meeting);
+        final Participant participant = new Participant(user, meeting, false);
+        final Attendance attendance = new Attendance(Status.NONE, false, participant, event);
+
+        // when
+        attendance.disable();
+
+        // then
+        assertThat(attendance.getDisabled()).isTrue();
+    }
+
+    @DisplayName("Attendance 상태가 Tardy인지 확인한다.")
+    @Test
+    void isTardy() {
+        // given
+        final User user = UserFixtures.KUN.create();
+        final Meeting meeting = MeetingFixtures.MORAGORA.create();
+        final Event event = EventFixtures.EVENT1.create(meeting);
+        final Participant participant = new Participant(user, meeting, false);
+        final Attendance attendance = new Attendance(Status.NONE, false, participant, event);
+
+        // when, then
+        assertThat(attendance.isTardy()).isFalse();
+    }
+
+    @DisplayName("Attendance 상태가 None 인지 확인한다.")
+    @Test
+    void isNone() {
+        // given
+        final User user = UserFixtures.KUN.create();
+        final Meeting meeting = MeetingFixtures.MORAGORA.create();
+        final Event event = EventFixtures.EVENT1.create(meeting);
+        final Participant participant = new Participant(user, meeting, false);
+        final Attendance attendance = new Attendance(Status.NONE, false, participant, event);
+
+        // when, then
+        assertThat(attendance.isNone()).isTrue();
+    }
+
+    @DisplayName("Attendance가 활성화 되있는지 확인한다.")
+    @Test
+    void isEnabled() {
+        // given
+        final User user = UserFixtures.KUN.create();
+        final Meeting meeting = MeetingFixtures.MORAGORA.create();
+        final Event event = EventFixtures.EVENT1.create(meeting);
+        final Participant participant = new Participant(user, meeting, false);
+        final Attendance attendance = new Attendance(Status.NONE, false, participant, event);
+
+        // when, then
+        assertThat(attendance.isEnabled()).isTrue();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/moragora/entity/EventTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/entity/EventTest.java
@@ -1,0 +1,81 @@
+package com.woowacourse.moragora.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.moragora.support.EventFixtures;
+import com.woowacourse.moragora.support.MeetingFixtures;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EventTest {
+
+    @DisplayName("같은 날짜의 이벤트인지 확인한다.")
+    @Test
+    void isSameDate() {
+        // given
+        final Meeting meeting = MeetingFixtures.MORAGORA.create();
+        final Event event = new Event(
+                LocalDate.of(2022, 8, 1),
+                LocalTime.of(10, 0),
+                LocalTime.of(18, 0),
+                meeting);
+
+        // when
+        final boolean actual = event.isSameDate(LocalDate.of(2022, 8, 1));
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @DisplayName("이벤트를 가지고 있는 미팅이 같은지 확인한다.")
+    @Test
+    void isSameMeeting() {
+        // given
+        final Meeting meeting = MeetingFixtures.MORAGORA.create();
+        final Event event = EventFixtures.EVENT1.create(meeting);
+
+        // when
+        final boolean actual = event.isSameMeeting(meeting);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @DisplayName("이벤트의 시간을 업데이트한다.")
+    @Test
+    void updateTime() {
+        // given
+        final Meeting meeting = MeetingFixtures.MORAGORA.create();
+        final Event event = EventFixtures.EVENT1.create(meeting);
+
+        // when
+        event.updateTime(LocalTime.of(10, 5), LocalTime.of(11, 5));
+
+        // then
+        assertAll(
+                () -> assertThat(event.getStartTime()).isEqualTo(LocalTime.of(10, 5)),
+                () -> assertThat(event.getEndTime()).isEqualTo(LocalTime.of(11, 5))
+        );
+    }
+
+    @DisplayName("이벤트가 이전 날짜인지 확인한다.")
+    @Test
+    void isDateBefore() {
+        // given
+        final Meeting meeting = MeetingFixtures.MORAGORA.create();
+        final Event event = new Event(
+                LocalDate.of(2022, 8, 1),
+                LocalTime.of(10, 0),
+                LocalTime.of(18, 0),
+                meeting);
+
+        // when
+        final boolean actual = event.isDateBefore(LocalDate.of(2022, 8, 2));
+
+        // then
+        assertThat(actual).isTrue();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/moragora/entity/EventTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/entity/EventTest.java
@@ -1,8 +1,10 @@
 package com.woowacourse.moragora.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.moragora.exception.meeting.IllegalEntranceLeaveTimeException;
 import com.woowacourse.moragora.support.EventFixtures;
 import com.woowacourse.moragora.support.MeetingFixtures;
 import java.time.LocalDate;
@@ -77,5 +79,17 @@ class EventTest {
 
         // then
         assertThat(actual).isTrue();
+    }
+
+    @DisplayName("이벤트를 업데이트하려고 할 때 시작시간이 종료시간보다 이후의 시간이라면 예외가 발생한다.")
+    @Test
+    void update_throwException_ifStartTimeIsAfterLeaveTime() {
+        // given
+        final Meeting meeting = MeetingFixtures.MORAGORA.create();
+        final Event event = EventFixtures.EVENT1.create(meeting);
+
+        // when, then
+        assertThatThrownBy(() -> event.updateTime(LocalTime.of(11, 5), LocalTime.of(10, 5)))
+                .isInstanceOf(IllegalEntranceLeaveTimeException.class);
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/entity/MeetingAttendancesTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/entity/MeetingAttendancesTest.java
@@ -2,9 +2,12 @@ package com.woowacourse.moragora.entity;
 
 import static com.woowacourse.moragora.entity.Provider.CHECKMATE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.moragora.entity.user.EncodedPassword;
 import com.woowacourse.moragora.entity.user.User;
+import com.woowacourse.moragora.support.EventFixtures;
+import com.woowacourse.moragora.support.UserFixtures;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -131,5 +134,31 @@ class MeetingAttendancesTest {
 
         // then
         assertThat(meetingAttendances.countTardy()).isEqualTo(3);
+    }
+
+    @DisplayName("MeetingAttendances 객체를 만들 때 Meeting이 2개 이상이면 예외가 발생한다.")
+    @Test
+    void validateSingleMeeting() {
+        // given
+        final User user = UserFixtures.KUN.create();
+        final Meeting meeting1 = Meeting.builder()
+                .id(1L)
+                .name("모라고라")
+                .build();
+
+        final Meeting meeting2 = Meeting.builder()
+                .id(2L)
+                .name("f12")
+                .build();
+
+        final Participant participant1 = new Participant(user, meeting1, false);
+        final Participant participant2 = new Participant(user, meeting2, false);
+        final Event event1 = EventFixtures.EVENT1.create(meeting1);
+        final Attendance attendance1 = new Attendance(Status.TARDY, false, participant1, event1);
+        final Attendance attendance2 = new Attendance(Status.TARDY, false, participant2, event1);
+
+        // when, then
+        assertThatThrownBy(() -> new MeetingAttendances(List.of(attendance1, attendance2), 2))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/entity/ParticipantAttendancesTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/entity/ParticipantAttendancesTest.java
@@ -1,0 +1,56 @@
+package com.woowacourse.moragora.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.woowacourse.moragora.entity.user.User;
+import com.woowacourse.moragora.support.EventFixtures;
+import com.woowacourse.moragora.support.MeetingFixtures;
+import com.woowacourse.moragora.support.UserFixtures;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ParticipantAttendancesTest {
+
+    @DisplayName("ParticipantAttendances 객체를 만들 때 참가자가 한명도 없다면 예외가 발생한다.")
+    @Test
+    void validateSingleParticipant() {
+
+        // given
+        final User user1 = UserFixtures.KUN.create();
+        final User user2 = UserFixtures.AZPI.create();
+        final Meeting meeting = MeetingFixtures.MORAGORA.create();
+        final Participant participant1 = new Participant(user1, meeting, false);
+        final Participant participant2 = new Participant(user2, meeting, false);
+        final Event event1 = EventFixtures.EVENT1.create(meeting);
+        final Attendance attendance1 = new Attendance(Status.TARDY, false, participant1, event1);
+        final Attendance attendance2 = new Attendance(Status.TARDY, false, participant2, event1);
+
+        // when, then
+        assertThatThrownBy(() -> new ParticipantAttendances(List.of(attendance1, attendance2)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("Participant의 지각횟수를 카운트한다.")
+    @Test
+    void countTardy() {
+        // given
+        final User user = UserFixtures.KUN.create();
+        final Meeting meeting = MeetingFixtures.MORAGORA.create();
+        final Participant participant = new Participant(user, meeting, false);
+        final Event event1 = EventFixtures.EVENT1.create(meeting);
+        final Event event2 = EventFixtures.EVENT2.create(meeting);
+
+        final List<Attendance> attendances = List.of(new Attendance(Status.TARDY, false, participant, event1),
+                new Attendance(Status.TARDY, false, participant, event2));
+
+        final ParticipantAttendances participantAttendances = new ParticipantAttendances(attendances);
+
+        // when
+        final int actual = participantAttendances.countTardy();
+
+        // then
+        assertThat(actual).isEqualTo(2);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/moragora/entity/ParticipantAttendancesTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/entity/ParticipantAttendancesTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 class ParticipantAttendancesTest {
 
-    @DisplayName("ParticipantAttendances 객체를 만들 때 참가자가 한명도 없다면 예외가 발생한다.")
+    @DisplayName("ParticipantAttendances 객체를 만들 때 참가자가 두명이상이라면 예외가 발생한다.")
     @Test
     void validateSingleParticipant() {
 

--- a/backend/src/test/java/com/woowacourse/moragora/entity/ParticipantTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/entity/ParticipantTest.java
@@ -1,0 +1,46 @@
+package com.woowacourse.moragora.entity;
+
+import static com.woowacourse.moragora.support.MeetingFixtures.MORAGORA;
+import static com.woowacourse.moragora.support.UserFixtures.KUN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.moragora.entity.user.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ParticipantTest {
+
+    @DisplayName("Meeting과 Participant를 맵핑한다.")
+    @Test
+    void mapMeeting() {
+        // given
+        final User user = KUN.create();
+        final Meeting meeting = MORAGORA.create();
+
+        final Participant participant = new Participant(user, meeting, false);
+
+        // when
+        participant.mapMeeting(meeting);
+
+        // then
+        assertThat(meeting.getParticipants().size()).isEqualTo(1);
+    }
+
+    @DisplayName("Meeting 목록에 이미 Participant가 있으면 포함하지 않는다.")
+    @Test
+    void mapMeeting_participantList() {
+        // given
+        final User user = KUN.create();
+        final Meeting meeting = MORAGORA.create();
+
+        final Participant participant = new Participant(user, meeting, false);
+        participant.mapMeeting(meeting);
+
+        // when
+        participant.mapMeeting(meeting);
+
+        // then
+        assertThat(meeting.getParticipants().size()).isEqualTo(1);
+
+    }
+}


### PR DESCRIPTION
Close #424 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/entity-test -> dev

## 요구사항
- 누락된 단위 테스트를 추가했습니다.

## 논의할 사항
- equals&hashcode를 @Lombok을 이용해서 정의하는 방법을 변경하였습니다.
기존에 ide에서 만든 equals hashcode 메서드는 jacoco에서 커버리지를 측정하기 때문에, 커버리지 기준에 못 미칠수도 있습니다. 
현재 lombok에서 제공하는 메서드들은 jacoco에서 제외가 되기 때문에 equals hashcode 정의 방법을 변경하는 것에 대해 어떻게 생각하신가요?

<img width="414" alt="image" src="https://user-images.githubusercontent.com/67885363/190573873-c0f3530a-49be-46af-b579-279587e03f26.png">
 
