### PR TITLE
[FE] 페이지에서 데이터를 불러왔을 때 에러 컴포넌트가 잠시 나타나는 버그 수정

### DIFF
--- a/frontend/src/components/CoffeeStackModal/index.tsx
+++ b/frontend/src/components/CoffeeStackModal/index.tsx
@@ -36,7 +36,7 @@ const CoffeeStackModal = ({ onDismiss, onConfirm }: CoffeeStackModalProps) => {
     );
   }
 
-  if (isError || !userCoffeeStatsResponse?.body) {
+  if (isError) {
     return (
       <S.Layout>
         <ErrorIcon />
@@ -51,7 +51,7 @@ const CoffeeStackModal = ({ onDismiss, onConfirm }: CoffeeStackModalProps) => {
     <S.Layout>
       <S.Title>It's 커피 타임~</S.Title>
       <S.StatsBox>
-        {userCoffeeStatsResponse.body.userCoffeeStats.map((data) => (
+        {userCoffeeStatsResponse?.body.userCoffeeStats.map((data) => (
           <S.RowBox key={data.id}>
             <span>{data.nickname}</span>
             <S.CoffeeIconBox>

--- a/frontend/src/pages/CheckInPage/index.tsx
+++ b/frontend/src/pages/CheckInPage/index.tsx
@@ -48,7 +48,7 @@ const CheckInPage = () => {
     );
   }
 
-  if (meetingListQuery.isError || !meetingListQuery.data) {
+  if (meetingListQuery.isError) {
     return (
       <>
         <S.Layout>
@@ -89,7 +89,7 @@ const CheckInPage = () => {
         <S.EndedCheckTimeSection>
           <S.SectionTitle>출결이 끝난 모임</S.SectionTitle>
           <S.MeetingList>
-            {meetingListQuery.data.body.meetings
+            {meetingListQuery.data?.body.meetings
               .filter((meeting) => !meeting.isActive)
               .map((meeting) => (
                 <CheckMeetingItem
@@ -106,7 +106,7 @@ const CheckInPage = () => {
         <S.CheckTimeSection>
           <S.SectionTitle>출결 중인 모임</S.SectionTitle>
           <S.MeetingList>
-            {meetingListQuery.data.body.meetings
+            {meetingListQuery.data?.body.meetings
               .filter((meeting) => meeting.isActive)
               .map((meeting) => (
                 <CheckMeetingItem

--- a/frontend/src/pages/MeetingDetailPage/index.tsx
+++ b/frontend/src/pages/MeetingDetailPage/index.tsx
@@ -83,7 +83,7 @@ const MeetingDetailPage = () => {
     );
   }
 
-  if (!id || meetingQuery.isError || !meetingQuery.data?.body) {
+  if (!id || meetingQuery.isError) {
     return (
       <>
         <S.Layout>

--- a/frontend/src/pages/MeetingListPage/index.tsx
+++ b/frontend/src/pages/MeetingListPage/index.tsx
@@ -108,7 +108,7 @@ const MeetingListPage = () => {
     );
   }
 
-  if (isError || !meetingListResponse?.body) {
+  if (isError) {
     return (
       <>
         <S.Layout>
@@ -126,7 +126,7 @@ const MeetingListPage = () => {
     );
   }
 
-  if (meetingListResponse.body.meetings.length === 0) {
+  if (meetingListResponse?.body.meetings.length === 0) {
     return (
       <>
         <S.Layout>
@@ -190,7 +190,7 @@ const MeetingListPage = () => {
             <S.Title>나의 커피 스택</S.Title>
           </S.TitleBox>
           <S.CoffeeStackList>
-            {meetingListResponse.body.meetings.map((meeting) => (
+            {meetingListResponse?.body.meetings.map((meeting) => (
               <li key={meeting.id}>
                 <CoffeeStackItem
                   name={meeting.name}


### PR DESCRIPTION
Close #426 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/fe/fix-appear-error -> dev

## 요구사항

- 각 페이지 로드 시 서버에서 데이터를 성공적으로 불러왔을 때 에러 컴포넌트가 나타나지 않는다.
  - 모임 목록 페이지
  - 모임 상세 페이지
  - 커피 스택 비우기 모달창
  - 출석 페이지

## 변경사항
- response body가 `undefined`인지 검사하는 조건 제거
- response body에 대한 optional 연산자 추가



