### PR TITLE
[BE] 유저 이메일 unique 제약 제거 및 회원가입 시 중복 검사 기능 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/moragora/application/UserService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/UserService.java
@@ -1,5 +1,6 @@
 package com.woowacourse.moragora.application;
 
+import static com.woowacourse.moragora.domain.user.Provider.CHECKMATE;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 
@@ -47,7 +48,7 @@ public class UserService {
 
     @Transactional
     public Long create(final UserRequest userRequest) {
-        validateUserExists(userRequest.getEmail());
+        validateUserExistsByEmailAndProvider(userRequest.getEmail());
         final User user = new User(userRequest.getEmail(), EncodedPassword.fromRawValue(userRequest.getPassword()),
                 userRequest.getNickname());
         final User savedUser = userRepository.save(user);
@@ -113,13 +114,9 @@ public class UserService {
         userRepository.delete(user);
     }
 
-    private void validateUserExists(final String email) {
-        final Optional<User> user = userRepository.findByEmail(email);
-        user.ifPresent(UserService::validateSameProvider);
-    }
-
-    private static void validateSameProvider(final User user) {
-        if (user.isProviderCheckmate()) {
+    private void validateUserExistsByEmailAndProvider(final String email) {
+        final Optional<User> user = userRepository.findByEmailAndProvider(email, CHECKMATE);
+        if (user.isPresent()) {
             throw new ClientRuntimeException("이미 사용중인 이메일입니다.", BAD_REQUEST);
         }
     }

--- a/backend/src/main/java/com/woowacourse/moragora/application/UserService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/UserService.java
@@ -59,7 +59,7 @@ public class UserService {
         if (email.isBlank()) {
             throw new NoParameterException();
         }
-        final boolean isExist = userRepository.findByEmail(email).isPresent();
+        final boolean isExist = userRepository.findByEmailAndProvider(email, CHECKMATE).isPresent();
         return new EmailCheckResponse(isExist);
     }
 

--- a/backend/src/main/java/com/woowacourse/moragora/application/auth/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/auth/AuthService.java
@@ -1,18 +1,20 @@
 package com.woowacourse.moragora.application.auth;
 
-import com.woowacourse.moragora.dto.response.user.GoogleProfileResponse;
+import static com.woowacourse.moragora.domain.user.Provider.CHECKMATE;
+import static com.woowacourse.moragora.domain.user.Provider.GOOGLE;
+
+import com.woowacourse.moragora.domain.participant.Participant;
+import com.woowacourse.moragora.domain.participant.ParticipantRepository;
+import com.woowacourse.moragora.domain.user.User;
+import com.woowacourse.moragora.domain.user.UserRepository;
+import com.woowacourse.moragora.domain.user.password.RawPassword;
 import com.woowacourse.moragora.dto.request.user.LoginRequest;
+import com.woowacourse.moragora.dto.response.user.GoogleProfileResponse;
 import com.woowacourse.moragora.dto.response.user.LoginResponse;
+import com.woowacourse.moragora.exception.participant.ParticipantNotFoundException;
 import com.woowacourse.moragora.exception.user.AuthenticationFailureException;
 import com.woowacourse.moragora.infrastructure.GoogleClient;
 import com.woowacourse.moragora.support.JwtTokenProvider;
-import com.woowacourse.moragora.domain.participant.Participant;
-import com.woowacourse.moragora.domain.user.Provider;
-import com.woowacourse.moragora.domain.user.password.RawPassword;
-import com.woowacourse.moragora.domain.user.User;
-import com.woowacourse.moragora.exception.participant.ParticipantNotFoundException;
-import com.woowacourse.moragora.domain.participant.ParticipantRepository;
-import com.woowacourse.moragora.domain.user.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,7 +38,7 @@ public class AuthService {
     }
 
     public LoginResponse createToken(final LoginRequest loginRequest) {
-        final User user = userRepository.findByEmail(loginRequest.getEmail())
+        final User user = userRepository.findByEmailAndProvider(loginRequest.getEmail(), CHECKMATE)
                 .orElseThrow(AuthenticationFailureException::new);
 
         final RawPassword rawPassword = new RawPassword(loginRequest.getPassword());
@@ -49,7 +51,7 @@ public class AuthService {
     public LoginResponse loginWithGoogle(final String code) {
         final String googleIdToken = googleClient.getIdToken(code);
         final GoogleProfileResponse profileResponse = googleClient.getProfileResponse(googleIdToken);
-        final User user = userRepository.findByEmailAndProvider(profileResponse.getEmail(), Provider.GOOGLE)
+        final User user = userRepository.findByEmailAndProvider(profileResponse.getEmail(), GOOGLE)
                 .orElseGet(() -> saveGoogleUser(profileResponse));
         final String accessToken = jwtTokenProvider.createToken(String.valueOf(user.getId()));
 
@@ -64,7 +66,7 @@ public class AuthService {
     }
 
     private User saveGoogleUser(final GoogleProfileResponse profileResponse) {
-        final User userToSave = new User(profileResponse.getEmail(), profileResponse.getName(), Provider.GOOGLE);
+        final User userToSave = new User(profileResponse.getEmail(), profileResponse.getName(), GOOGLE);
         return userRepository.save(userToSave);
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/domain/user/User.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/user/User.java
@@ -86,10 +86,6 @@ public class User {
         this.password = newPassword;
     }
 
-    public boolean isProviderCheckmate() {
-        return this.provider == CHECKMATE;
-    }
-
     private void validateEmail(final String email) {
         final Matcher matcher = PATTERN_EMAIL.matcher(email);
         if (!matcher.matches()) {

--- a/backend/src/main/java/com/woowacourse/moragora/domain/user/User.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/user/User.java
@@ -6,7 +6,6 @@ import com.woowacourse.moragora.domain.user.password.EncodedPassword;
 import com.woowacourse.moragora.domain.user.password.RawPassword;
 import com.woowacourse.moragora.exception.global.InvalidFormatException;
 import com.woowacourse.moragora.exception.user.AuthenticationFailureException;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.persistence.Column;
@@ -19,6 +18,8 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.EqualsAndHashCode.Include;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,6 +27,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "user")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class User {
 
     private static final String REGEX_EMAIL = "^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$";
@@ -34,9 +36,10 @@ public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Include
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String email;
 
     @Column(nullable = false)
@@ -83,6 +86,10 @@ public class User {
         this.password = newPassword;
     }
 
+    public boolean isProviderCheckmate() {
+        return this.provider == CHECKMATE;
+    }
+
     private void validateEmail(final String email) {
         final Matcher matcher = PATTERN_EMAIL.matcher(email);
         if (!matcher.matches()) {
@@ -94,22 +101,5 @@ public class User {
         if (nickname.length() > NICKNAME_LENGTH_LENGTH) {
             throw new InvalidFormatException();
         }
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        final User user = (User) o;
-        return Objects.equals(id, user.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id);
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/domain/user/UserRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/user/UserRepository.java
@@ -16,7 +16,7 @@ public interface UserRepository extends Repository<User, Long> {
 
     Optional<User> findByEmail(final String email);
 
-    Optional<User> findByEmailAndProvider(String email, Provider google);
+    Optional<User> findByEmailAndProvider(String email, Provider provider);
 
     @Query("select u from User u where u.nickname like %:keyword% or u.email like %:keyword%")
     List<User> findByNicknameOrEmailLike(@Param("keyword") final String keyword);

--- a/backend/src/main/java/com/woowacourse/moragora/domain/user/UserRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/user/UserRepository.java
@@ -14,8 +14,6 @@ public interface UserRepository extends Repository<User, Long> {
 
     List<User> findByIdIn(final List<Long> ids);
 
-    Optional<User> findByEmail(final String email);
-
     Optional<User> findByEmailAndProvider(String email, Provider provider);
 
     @Query("select u from User u where u.nickname like %:keyword% or u.email like %:keyword%")

--- a/backend/src/main/java/com/woowacourse/moragora/domain/user/UserRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/user/UserRepository.java
@@ -14,7 +14,7 @@ public interface UserRepository extends Repository<User, Long> {
 
     List<User> findByIdIn(final List<Long> ids);
 
-    Optional<User> findByEmailAndProvider(String email, Provider provider);
+    Optional<User> findByEmailAndProvider(final String email, final Provider provider);
 
     @Query("select u from User u where u.nickname like %:keyword% or u.email like %:keyword%")
     List<User> findByNicknameOrEmailLike(@Param("keyword") final String keyword);

--- a/backend/src/test/java/com/woowacourse/moragora/application/UserServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/application/UserServiceTest.java
@@ -4,6 +4,7 @@ import static com.woowacourse.moragora.support.fixture.MeetingFixtures.MORAGORA;
 import static com.woowacourse.moragora.support.fixture.UserFixtures.BATD;
 import static com.woowacourse.moragora.support.fixture.UserFixtures.KUN;
 import static com.woowacourse.moragora.support.fixture.UserFixtures.MASTER;
+import static com.woowacourse.moragora.support.fixture.UserFixtures.SUN;
 import static com.woowacourse.moragora.support.fixture.UserFixtures.createUsers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -63,6 +64,19 @@ class UserServiceTest {
 
         // then
         assertThat(id).isNotNull();
+    }
+
+    @DisplayName("새로운 회원을 생성한다.")
+    @Test
+    void create_throwsException_ifDuplicatedEmailAndProvider() {
+        // given
+        dataSupport.saveUser(SUN.create());
+        final UserRequest userRequest = new UserRequest(SUN.getEmail(), "asdf1234!", "sunny");
+
+        // when, then
+        assertThatThrownBy(() -> userService.create(userRequest))
+                .isInstanceOf(ClientRuntimeException.class)
+                .hasMessage("이미 사용중인 이메일입니다.");
     }
 
     @DisplayName("중복되지 않은 이메일의 중복 여부를 확인한다.")

--- a/backend/src/test/java/com/woowacourse/moragora/domain/user/UserRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/domain/user/UserRepositoryTest.java
@@ -61,21 +61,21 @@ class UserRepositoryTest {
         final List<User> users = userRepository.findByIdIn(List.of(user1.getId(), user2.getId(), user3.getId()));
 
         // then
-        assertThat(users.containsAll(List.of(user1, user2, user3))).isTrue();
+        assertThat(users).containsAll(List.of(user1, user2, user3));
     }
 
-    @DisplayName("이메일로 유저를 검색한다.")
+    @DisplayName("이메일과 provider로 유저를 검색한다.")
     @Test
-    void findByEmail() {
+    void findByEmailAndProvider() {
         // given
         final User user = KUN.create();
         final User savedUser = userRepository.save(user);
 
         // when
-        final Optional<User> foundUser = userRepository.findByEmail(savedUser.getEmail());
+        final Optional<User> foundUser = userRepository.findByEmailAndProvider(savedUser.getEmail(), Provider.CHECKMATE);
 
         // then
-        assertThat(foundUser.isPresent()).isTrue();
+        assertThat(foundUser).isPresent();
     }
 
     @DisplayName("keyword로 유저를 검색할 수 있다.")

--- a/backend/src/test/java/com/woowacourse/moragora/domain/user/UserTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/domain/user/UserTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.moragora.domain.user;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -95,5 +96,18 @@ class UserTest {
         // when, then
         assertThatThrownBy(() -> user.updateNickname(nickname))
                 .isInstanceOf(InvalidFormatException.class);
+    }
+
+    @DisplayName("Provider가 CHECKMATE인지 확인한다.")
+    @Test
+    void isProviderCheckmate() {
+        // given
+        final User user = new User("sun@email.com", EncodedPassword.fromRawValue("asdfqer1!"), "sun");
+
+        // when
+        final boolean expected = user.isProviderCheckmate();
+
+        // then
+        assertThat(expected).isTrue();
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/domain/user/UserTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/domain/user/UserTest.java
@@ -1,6 +1,5 @@
 package com.woowacourse.moragora.domain.user;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -96,18 +95,5 @@ class UserTest {
         // when, then
         assertThatThrownBy(() -> user.updateNickname(nickname))
                 .isInstanceOf(InvalidFormatException.class);
-    }
-
-    @DisplayName("Provider가 CHECKMATE인지 확인한다.")
-    @Test
-    void isProviderCheckmate() {
-        // given
-        final User user = new User("sun@email.com", EncodedPassword.fromRawValue("asdfqer1!"), "sun");
-
-        // when
-        final boolean expected = user.isProviderCheckmate();
-
-        // then
-        assertThat(expected).isTrue();
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/support/fixture/UserFixtures.java
+++ b/backend/src/test/java/com/woowacourse/moragora/support/fixture/UserFixtures.java
@@ -1,5 +1,7 @@
 package com.woowacourse.moragora.support.fixture;
 
+import static com.woowacourse.moragora.domain.user.Provider.CHECKMATE;
+
 import com.woowacourse.moragora.domain.user.User;
 import com.woowacourse.moragora.domain.user.password.EncodedPassword;
 import java.util.List;
@@ -51,6 +53,7 @@ public enum UserFixtures {
                 .email(this.email)
                 .password(this.password)
                 .nickname(this.nickname)
+                .provider(CHECKMATE)
                 .build();
     }
 


### PR DESCRIPTION
Close #452 #420 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/register -> dev

## 요구사항
- 회원가입 시 같은 이메일과 provider로 이미 존재하는지 검증한다.

## 변경사항
- User의 email unique 제약을 제거한다.

