### PR TITLE
[BE] User 정보 응답 시 회원가입 기관 정보 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/moragora/dto/response/user/UserResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/response/user/UserResponse.java
@@ -24,9 +24,11 @@ public class UserResponse {
     }
 
     public static UserResponse from(final User user) {
-        return new UserResponse(user.getId(),
+        return new UserResponse(
+                user.getId(),
                 user.getEmail(),
                 user.getNickname(),
-                user.getProvider().name());
+                user.getProvider().name()
+        );
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/response/user/UserResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/response/user/UserResponse.java
@@ -1,6 +1,7 @@
 package com.woowacourse.moragora.dto.response.user;
 
 import com.woowacourse.moragora.domain.user.User;
+import java.util.Locale;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -11,16 +12,22 @@ public class UserResponse {
     private final Long id;
     private final String email;
     private final String nickname;
+    private final String authProvider;
 
     public UserResponse(final Long id,
                         final String email,
-                        final String nickname) {
+                        final String nickname,
+                        final String authProvider) {
         this.id = id;
         this.email = email;
         this.nickname = nickname;
+        this.authProvider = authProvider;
     }
 
     public static UserResponse from(final User user) {
-        return new UserResponse(user.getId(), user.getEmail(), user.getNickname());
+        final String authProvider = user.getProvider()
+                .name()
+                .toLowerCase(Locale.ROOT);
+        return new UserResponse(user.getId(), user.getEmail(), user.getNickname(), authProvider);
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/response/user/UserResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/response/user/UserResponse.java
@@ -1,7 +1,6 @@
 package com.woowacourse.moragora.dto.response.user;
 
 import com.woowacourse.moragora.domain.user.User;
-import java.util.Locale;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -21,13 +20,13 @@ public class UserResponse {
         this.id = id;
         this.email = email;
         this.nickname = nickname;
-        this.authProvider = authProvider;
+        this.authProvider = authProvider.toLowerCase();
     }
 
     public static UserResponse from(final User user) {
-        final String authProvider = user.getProvider()
-                .name()
-                .toLowerCase(Locale.ROOT);
-        return new UserResponse(user.getId(), user.getEmail(), user.getNickname(), authProvider);
+        return new UserResponse(user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getProvider().name());
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/UserAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/UserAcceptanceTest.java
@@ -89,8 +89,7 @@ class UserAcceptanceTest extends AcceptanceTest {
                 .collect(Collectors.toList());
 
         final List<String> providers = users.stream()
-                .map(User::getProvider)
-                .map(provider -> provider.name().toLowerCase())
+                .map(user -> user.getProvider().name().toLowerCase())
                 .collect(Collectors.toList());
 
         // when

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/UserAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/UserAcceptanceTest.java
@@ -16,6 +16,7 @@ import com.woowacourse.moragora.dto.request.user.UserDeleteRequest;
 import com.woowacourse.moragora.dto.request.user.UserRequest;
 import io.restassured.response.ValidatableResponse;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -88,6 +89,12 @@ class UserAcceptanceTest extends AcceptanceTest {
                 .map(User::getEmail)
                 .collect(Collectors.toList());
 
+        final List<String> providers = users.stream()
+                .map(User::getProvider)
+                .map(provider -> provider.name().toLowerCase(Locale.ROOT))
+                .collect(Collectors.toList());
+        System.out.println(providers);
+
         // when
         final ValidatableResponse response = get("/users?keyword=" + keyword);
 
@@ -95,7 +102,8 @@ class UserAcceptanceTest extends AcceptanceTest {
         response.statusCode(HttpStatus.OK.value())
                 .body("users.id", equalTo(userIds))
                 .body("users.nickname", equalTo(nicknames))
-                .body("users.email", equalTo(emails));
+                .body("users.email", equalTo(emails))
+                .body("users.authProvider", equalTo(providers));
     }
 
     @DisplayName("로그인 한 상태에서 자신의 회원정보를 요청하면 회원정보와 상태코드 200을 반환받는다.")
@@ -112,7 +120,8 @@ class UserAcceptanceTest extends AcceptanceTest {
         response.statusCode(HttpStatus.OK.value())
                 .body("id", equalTo(id.intValue()))
                 .body("email", equalTo(user.getEmail()))
-                .body("nickname", equalTo(user.getNickname()));
+                .body("nickname", equalTo(user.getNickname()))
+                .body("authProvider", equalTo(user.getProvider().name().toLowerCase(Locale.ROOT)));
     }
 
     @DisplayName("로그인 한 상태에서 닉네임 수정을 요청하면 닉네임을 수정한 후 상태코드 204을 반환한다.")

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/UserAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/UserAcceptanceTest.java
@@ -16,7 +16,6 @@ import com.woowacourse.moragora.dto.request.user.UserDeleteRequest;
 import com.woowacourse.moragora.dto.request.user.UserRequest;
 import io.restassured.response.ValidatableResponse;
 import java.util.List;
-import java.util.Locale;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -91,9 +90,8 @@ class UserAcceptanceTest extends AcceptanceTest {
 
         final List<String> providers = users.stream()
                 .map(User::getProvider)
-                .map(provider -> provider.name().toLowerCase(Locale.ROOT))
+                .map(provider -> provider.name().toLowerCase())
                 .collect(Collectors.toList());
-        System.out.println(providers);
 
         // when
         final ValidatableResponse response = get("/users?keyword=" + keyword);
@@ -121,7 +119,7 @@ class UserAcceptanceTest extends AcceptanceTest {
                 .body("id", equalTo(id.intValue()))
                 .body("email", equalTo(user.getEmail()))
                 .body("nickname", equalTo(user.getNickname()))
-                .body("authProvider", equalTo(user.getProvider().name().toLowerCase(Locale.ROOT)));
+                .body("authProvider", equalTo(user.getProvider().name().toLowerCase()));
     }
 
     @DisplayName("로그인 한 상태에서 닉네임 수정을 요청하면 닉네임을 수정한 후 상태코드 204을 반환한다.")

--- a/backend/src/test/java/com/woowacourse/moragora/application/UserServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/application/UserServiceTest.java
@@ -149,10 +149,11 @@ class UserServiceTest {
         // given
         final String email = "kun@naver.com";
         final String nickname = "kun";
+        final String authProvider = "checkmate";
         final UserRequest userRequest = new UserRequest(email, "1234smart!", nickname);
         final Long id = userService.create(userRequest);
 
-        final UserResponse expectedResponse = new UserResponse(id, email, nickname);
+        final UserResponse expectedResponse = new UserResponse(id, email, nickname, authProvider);
 
         // when
         final UserResponse response = userService.findById(id);

--- a/backend/src/test/java/com/woowacourse/moragora/application/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/application/auth/AuthServiceTest.java
@@ -145,7 +145,7 @@ class AuthServiceTest {
                 .willReturn("something");
         given(googleClient.getProfileResponse(anyString()))
                 .willReturn(new GoogleProfileResponse("sunny@gmail.com", "썬"));
-        final UserResponse expectedResponse = new UserResponse(null, "sunny@gmail.com", "썬");
+        final UserResponse expectedResponse = new UserResponse(null, "sunny@gmail.com", "썬", "google");
 
         // when
         final LoginResponse loginResponse = authService.loginWithGoogle("codecode");

--- a/backend/src/test/java/com/woowacourse/moragora/presentation/UserControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/presentation/UserControllerTest.java
@@ -149,13 +149,13 @@ class UserControllerTest extends ControllerTest {
 
         final UsersResponse usersResponse = new UsersResponse(
                 List.of(
-                        new UserResponse(1L, "aaa111@foo.com", "아스피"),
-                        new UserResponse(2L, "bbb222@foo.com", "필즈"),
-                        new UserResponse(3L, "ccc333@foo.com", "포키"),
-                        new UserResponse(4L, "ddd444@foo.com", "썬"),
-                        new UserResponse(5L, "eee555@foo.com", "우디"),
-                        new UserResponse(6L, "fff666@foo.com", "쿤"),
-                        new UserResponse(7L, "ggg777@foo.com", "반듯"))
+                        new UserResponse(1L, "aaa111@foo.com", "아스피", "checkmate"),
+                        new UserResponse(2L, "bbb222@foo.com", "필즈", "checkmate"),
+                        new UserResponse(3L, "ccc333@foo.com", "포키", "checkmate"),
+                        new UserResponse(4L, "ddd444@foo.com", "썬", "checkmate"),
+                        new UserResponse(5L, "eee555@foo.com", "우디", "checkmate"),
+                        new UserResponse(6L, "fff666@foo.com", "쿤", "checkmate"),
+                        new UserResponse(7L, "ggg777@foo.com", "반듯", "checkmate"))
         );
 
         given(userService.searchByKeyword(keyword))
@@ -177,12 +177,16 @@ class UserControllerTest extends ControllerTest {
                         "ggg777@foo.com")))
                 .andExpect(jsonPath("$.users[*].nickname", containsInAnyOrder(
                         "아스피", "필즈", "포키", "썬", "우디", "쿤", "반듯")))
+                .andExpect(jsonPath("$.users[*].authProvider", containsInAnyOrder(
+                        "checkmate", "checkmate", "checkmate", "checkmate", "checkmate", "checkmate", "checkmate")))
                 .andDo(document("user/keyword-search",
                         preprocessResponse(prettyPrint()),
                         responseFields(
                                 fieldWithPath("users[].id").type(JsonFieldType.NUMBER).description(1L),
                                 fieldWithPath("users[].email").type(JsonFieldType.STRING).description("aaa111@foo.com"),
-                                fieldWithPath("users[].nickname").type(JsonFieldType.STRING).description("아스피")
+                                fieldWithPath("users[].nickname").type(JsonFieldType.STRING).description("아스피"),
+                                fieldWithPath("users[].authProvider").type(JsonFieldType.STRING)
+                                        .description("checkmate")
                         )
                 ));
     }
@@ -210,7 +214,8 @@ class UserControllerTest extends ControllerTest {
         final long id = 1L;
         final String email = "foo@email.com";
         final String nickname = "foo";
-        final UserResponse userResponse = new UserResponse(id, email, nickname);
+        final String authProvider = "checkmate";
+        final UserResponse userResponse = new UserResponse(id, email, nickname, authProvider);
 
         validateToken("1");
         given(userService.findById(id))
@@ -224,12 +229,14 @@ class UserControllerTest extends ControllerTest {
                 .andExpect(jsonPath("id").value(id))
                 .andExpect(jsonPath("email").value(email))
                 .andExpect(jsonPath("nickname").value(nickname))
+                .andExpect(jsonPath("authProvider").value(authProvider))
                 .andDo(document("user/find-my-info",
                         preprocessResponse(prettyPrint()),
                         responseFields(
                                 fieldWithPath("id").type(JsonFieldType.NUMBER).description(1L),
                                 fieldWithPath("email").type(JsonFieldType.STRING).description("foo@email.com"),
-                                fieldWithPath("nickname").type(JsonFieldType.STRING).description("foo")
+                                fieldWithPath("nickname").type(JsonFieldType.STRING).description("foo"),
+                                fieldWithPath("authProvider").type(JsonFieldType.STRING).description("checkmate")
                         )
                 ));
     }


### PR DESCRIPTION
<!--Close #issue_number를 작성한다.-->
Close #458 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/user-find-refactor -> dev

## 요구사항
<!--로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
- User 정보 응답 시 회원가입 기관 정보 추가

## 변경사항
- UserResponse에 authProvider 추가
- 
## [Optional] 논의하고 싶은 내용

