### PR TITLE
[FE] OAuth 로그인 유저 비밀번호 수정, 회원 탈퇴 방식 변경

### DIFF
--- a/frontend/src/contexts/userContext.tsx
+++ b/frontend/src/contexts/userContext.tsx
@@ -1,10 +1,9 @@
 import { getLoginUserDataApi } from 'apis/userApis';
 import useQuery from 'hooks/useQuery';
 import React, { createContext, useState } from 'react';
-import { QueryClient } from 'types/queryType';
 import { User } from 'types/userType';
 
-type UserContextData = Pick<User, 'id' | 'email' | 'nickname' | 'accessToken'>;
+type UserContextData = Omit<User, 'password'>;
 
 export type UserContextValues = {
   user: UserContextData | null;

--- a/frontend/src/mocks/fixtures/users.ts
+++ b/frontend/src/mocks/fixtures/users.ts
@@ -1,13 +1,17 @@
-import { User } from 'types/userType';
+import { AuthProvider, User } from 'types/userType';
+
+const LENGTH = 100;
 
 const generateIndexes = (length: number) => Array.from({ length });
 
-const users = generateIndexes(100).map<User>((_, id) => ({
+const users = generateIndexes(LENGTH).map<User>((_, id) => ({
   id,
   email: `user${id}@google.com`,
   password: `user${id}pw!`,
   nickname: `user${id}`,
   accessToken: null,
+  authProvider:
+    id === LENGTH - 1 ? AuthProvider['google'] : AuthProvider['checkmate'],
 }));
 
 export default users;

--- a/frontend/src/mocks/handlers/userHandler.ts
+++ b/frontend/src/mocks/handlers/userHandler.ts
@@ -4,6 +4,7 @@ import {
   UserRegisterRequestBody,
   UserLoginRequestBody,
   User,
+  AuthProvider,
 } from 'types/userType';
 import { DELAY } from 'mocks/configs';
 import { extractIdFromHeader, generateToken } from 'mocks/utils';
@@ -56,6 +57,7 @@ export default [
         password,
         nickname,
         accessToken: null,
+        authProvider: AuthProvider['checkmate'],
       };
 
       users.push(newUser);
@@ -109,7 +111,7 @@ export default [
         );
       }
 
-      const targetUser = users[0];
+      const targetUser = users[users.length - 1];
       const accessToken = generateToken(targetUser.id);
 
       targetUser.accessToken = accessToken;
@@ -182,6 +184,7 @@ export default [
         id: user.id,
         email: user.email,
         nickname: user.nickname,
+        authProvider: user.authProvider,
       }),
       ctx.delay(DELAY)
     );

--- a/frontend/src/pages/UserConfigPage/index.tsx
+++ b/frontend/src/pages/UserConfigPage/index.tsx
@@ -7,6 +7,7 @@ import NicknameInput from 'components/NicknameInput';
 import { userContext } from 'contexts/userContext';
 import useMutation from 'hooks/useMutation';
 import { updateNicknameApi } from 'apis/userApis';
+import { AuthProvider } from 'types/userType';
 
 const UserConfigPage = () => {
   const user = useContext(userContext);
@@ -115,6 +116,7 @@ const UserConfigPage = () => {
               />
             </svg>
           }
+          disabled={user.user?.authProvider !== AuthProvider['checkmate']}
         >
           비밀번호 변경
         </MenuLink>
@@ -137,6 +139,7 @@ const UserConfigPage = () => {
               />
             </svg>
           }
+          disabled={user.user?.authProvider !== AuthProvider['checkmate']}
         >
           회원 탈퇴
         </MenuLink>

--- a/frontend/src/types/userType.ts
+++ b/frontend/src/types/userType.ts
@@ -1,3 +1,8 @@
+export enum AuthProvider {
+  checkmate = 'checkmate',
+  google = 'google',
+}
+
 export type AttendanceStatus = 'none' | 'present' | 'tardy';
 
 export type User = {
@@ -6,9 +11,10 @@ export type User = {
   password: string;
   nickname: string;
   accessToken: string | null;
+  authProvider: keyof typeof AuthProvider;
 };
 
-export type Participant = Omit<User, 'password' | 'accessToken'> & {
+export type Participant = Pick<User, 'id' | 'email' | 'nickname'> & {
   tardyCount: number;
   attendanceStatus: AttendanceStatus;
 };
@@ -29,9 +35,9 @@ export type UserLoginResponseBody = Pick<User, 'accessToken'>;
 
 export type GoogleLoginRequestBody = { code: string };
 
-export type GetLoginUserDataResponseBody = Pick<
+export type GetLoginUserDataResponseBody = Omit<
   User,
-  'id' | 'nickname' | 'email'
+  'password' | 'accessToken'
 >;
 
 export type UserUpdateNicknameRequestBody = Pick<User, 'nickname'>;


### PR DESCRIPTION
Close #456 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/fe/oauth-userconfig-change -> dev

## 요구사항
- [x] 비밀번호 변경
  - 비밀번호 변경 페이지 접근을 제한한다.
  - UserConfigPage의 비밀번호 변경 메뉴를 비활성화 한다.
- [ ] 회원 탈퇴
  - 회원 탈퇴 서명만 받고, 비밀번호는 받지 않는다.

## 변경사항
mockgin 수정
- user 데이터에 authProvider 추가
- login/oauth에 targetUser를 user2로 변경 및 authProvider ‘google’로 변경
- new User 수정
- users/me 응답에 authProvider 추가

타입 수정
- userContext에 UserContextData 타입 수정
- User 타입 수정
- Participant 타입 수정
- GetLoginUserDataResponseBody 타입 수정

도메인 수정
- UserConfigPage 비밀 번호 변경 및 회원 탈퇴 메뉴 비활성화

### 회원 탈퇴 관련 논의 내용
- OAuth 로그인 유저 회원 탈퇴를 위해서 비밀번호를 받지 않는 새로운 api구현
- 비밀번호를 받지 않고 바로 탈퇴를 하게 되면 타인이 쉽게 탈퇴를 시켜버릴 수 있다
  -> 탈퇴 전에 모달로 한번더 확인하는 것으로 합의
- Google 계정으로 부여된 로그인 권한을 delete 시켜야 한다.
  -> 서버에서 현재 accessToken 및 refreshToken을 저장하지 않고 있고, 권한을 취속하기 위해서 accessToken 재요청 및 refreshToken 저장방식을 고민해봐야하는 이유가 있기 때문에 다음 스프린트에서 시간을 잡고 구현한다.

>이런한 이유로 현재 OAuth 로그인 유저일 경우에 `userConfigPage`에서 메뉴를 비활성화하는 것을 결론을 냈습니다.

비활성화 방법: `MenuLink` 컴포넌트 `disable` prop 사용
