### PR TITLE
[BE] 출석 시간 전이 아닌 현재시간 이전의 이벤트 생성을 못하도록 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/moragora/application/EventService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/EventService.java
@@ -206,8 +206,8 @@ public class EventService {
                 .findAny();
 
         event.ifPresent(it -> {
-            if (serverTimeManager.isAfterAttendanceStartTime(it.getStartTime())) {
-                throw new ClientRuntimeException("출석 시간 전에 일정을 생성할 수 없습니다.", HttpStatus.BAD_REQUEST);
+            if (serverTimeManager.isAfter(it.getStartTime())) {
+                throw new ClientRuntimeException("과거의 일정을 생성할 수 없습니다.", HttpStatus.BAD_REQUEST);
             }
         });
     }

--- a/backend/src/main/java/com/woowacourse/moragora/application/ServerTimeManager.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/ServerTimeManager.java
@@ -33,8 +33,8 @@ public class ServerTimeManager {
         return dateTime.isAfter(closingTime);
     }
 
-    public boolean isAfter(final LocalTime startTime) {
-        return dateTime.isAfter(startTime);
+    public boolean isAfter(final LocalTime localTime) {
+        return dateTime.isAfter(localTime);
     }
 
     public LocalTime calculateOpenTime(final LocalTime meetingStartTime) {

--- a/backend/src/main/java/com/woowacourse/moragora/application/ServerTimeManager.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/ServerTimeManager.java
@@ -33,6 +33,10 @@ public class ServerTimeManager {
         return dateTime.isAfter(closingTime);
     }
 
+    public boolean isAfter(final LocalTime startTime) {
+        return dateTime.isAfter(startTime);
+    }
+
     public boolean isAfterAttendanceStartTime(final LocalTime startTime) {
         return this.dateTime.isAfter(startTime.minusMinutes(ATTENDANCE_START_INTERVAL));
     }

--- a/backend/src/main/java/com/woowacourse/moragora/application/ServerTimeManager.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/ServerTimeManager.java
@@ -37,10 +37,6 @@ public class ServerTimeManager {
         return dateTime.isAfter(startTime);
     }
 
-    public boolean isAfterAttendanceStartTime(final LocalTime startTime) {
-        return this.dateTime.isAfter(startTime.minusMinutes(ATTENDANCE_START_INTERVAL));
-    }
-
     public LocalTime calculateOpenTime(final LocalTime meetingStartTime) {
         return meetingStartTime.minusMinutes(ATTENDANCE_START_INTERVAL);
     }

--- a/backend/src/main/java/com/woowacourse/moragora/support/timestrategy/DateTime.java
+++ b/backend/src/main/java/com/woowacourse/moragora/support/timestrategy/DateTime.java
@@ -7,7 +7,7 @@ public abstract class DateTime {
 
     protected LocalDateTime value;
 
-    public DateTime(final LocalDateTime dateTime) {
+    protected DateTime(final LocalDateTime dateTime) {
         this.value = dateTime;
     }
 
@@ -23,8 +23,8 @@ public abstract class DateTime {
                 time.equals(startTime);
     }
 
-    public boolean isAfter(final LocalTime endTime) {
-        final LocalTime time = value.toLocalTime();
-        return time.isAfter(endTime);
+    public boolean isAfter(final LocalTime other) {
+        final LocalTime localTime = value.toLocalTime();
+        return localTime.isAfter(other);
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/AttendanceAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/AttendanceAcceptanceTest.java
@@ -57,7 +57,7 @@ class AttendanceAcceptanceTest extends AcceptanceTest {
                 .meeting(meeting)
                 .build();
 
-        given(serverTimeManager.isAfterAttendanceStartTime(any(LocalTime.class)))
+        given(serverTimeManager.isAfter(any(LocalTime.class)))
                 .willReturn(false);
         given(serverTimeManager.getDate())
                 .willReturn(LocalDate.now());

--- a/backend/src/test/java/com/woowacourse/moragora/application/EventServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/application/EventServiceTest.java
@@ -157,12 +157,12 @@ class EventServiceTest {
                 .hasMessage("하루에 복수의 일정을 생성할 수 없습니다.");
     }
 
-    @DisplayName("오늘의 이벤트 생성 시, 이벤트 시작 시간이 출석 시작 시간보다 이후일 경우 예외가 발생한다.")
+    @DisplayName("오늘의 이벤트 생성 시, 이벤트 시작 시간이 현재 시간 이후일 경우 예외가 발생한다.")
     @Test
-    void save_throwsException_ifTodayEventStartTimeIsAfterAttendanceStartTime() {
+    void save_throwsException_ifTodayEventStartTimeIsAfterNow() {
         // given
         final LocalDate date = LocalDate.of(2022, 8, 1);
-        final LocalTime time = LocalTime.of(9, 30, 1);
+        final LocalTime time = LocalTime.of(10, 0, 1);
         final LocalDateTime now = LocalDateTime.of(date, time);
         serverTimeManager.refresh(now);
 
@@ -179,7 +179,7 @@ class EventServiceTest {
         // when, then
         assertThatThrownBy(() -> eventService.save(eventsRequest, meeting.getId()))
                 .isInstanceOf(ClientRuntimeException.class)
-                .hasMessage("출석 시간 전에 일정을 생성할 수 없습니다.");
+                .hasMessage("과거의 일정을 생성할 수 없습니다.");
     }
 
 


### PR DESCRIPTION
<!--Close #issue_number를 작성한다.-->
#477 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/event-create -> dev

## 요구사항
현재 시간 이후로 일정을 생성할 수 있도록 변경한다.

## 변경사항
- 기존에 출석시간 이후로 일정을 생성할 수 있도록 되어있었는데,현재 시간 이후로 일정을 생성하도록 변경한다.

