### PR TITLE
[BE] LoginInterceptor annotation 검사 로직 오류 수정 및 hotfix

### DIFF
--- a/backend/src/main/java/com/woowacourse/moragora/presentation/auth/LoginInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/moragora/presentation/auth/LoginInterceptor.java
@@ -41,7 +41,7 @@ public class LoginInterceptor implements HandlerInterceptor {
 
     private boolean isNotAnnotated(final Object handler) {
         final HandlerMethod handlerMethod = (HandlerMethod) handler;
-        final Authentication classAnnotation = handlerMethod.getBean().getClass().getAnnotation(Authentication.class);
+        final Authentication classAnnotation = handlerMethod.getBeanType().getAnnotation(Authentication.class);
         final Authentication methodAnnotation = handlerMethod.getMethodAnnotation(Authentication.class);
         return Objects.isNull(classAnnotation) && Objects.isNull(methodAnnotation);
     }


### PR DESCRIPTION
<!--Close #issue_number를 작성한다.-->
Close #486 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
hotfix/1.1.2 -> main

## 요구사항
<!--로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
만료된 토큰에 대한 응답을 500에서 401로 수정한다

## 변경사항
Class Annotation 검사 시 `getBean().getClass()`하면 프록시 관련 객체 class가 반환됨
`getBeanType()`으로 해야 Controller Class 반환

## [Optional] 논의하고 싶은 내용

