### PR TITLE
[BE] 미팅 조회에서의 findById 최적화

### DIFF
--- a/backend/src/main/java/com/woowacourse/moragora/domain/exception/BusinessException.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/exception/BusinessException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.moragora.domain.exception;
+
+public class BusinessException extends RuntimeException {
+
+    public BusinessException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/moragora/domain/meeting/Meeting.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/meeting/Meeting.java
@@ -1,9 +1,11 @@
 package com.woowacourse.moragora.domain.meeting;
 
 import com.woowacourse.moragora.domain.participant.Participant;
+import com.woowacourse.moragora.domain.participant.ParticipantAndCount;
 import com.woowacourse.moragora.exception.global.InvalidFormatException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -59,6 +61,26 @@ public class Meeting {
         return participants.stream()
                 .map(Participant::getId)
                 .collect(Collectors.toUnmodifiableList());
+    }
+
+    public Optional<Participant> findParticipant(final Long userId) {
+        return participants.stream()
+                .filter(it -> it.isSameParticipant(userId))
+                .findAny();
+    }
+
+    public void allocateParticipantsTardyCount(final List<ParticipantAndCount> participantAndCounts) {
+        participantAndCounts.forEach(it -> it.getParticipant().allocateTardyCount(it.getTardyCount()));
+    }
+
+    public Boolean isTardyStackFull() {
+        return calculateTardy() >= participants.size();
+    }
+
+    public long calculateTardy() {
+        return participants.stream()
+                .mapToLong(Participant::getTardyCount)
+                .sum();
     }
 
     private void validateName(final String name) {

--- a/backend/src/main/java/com/woowacourse/moragora/domain/meeting/MeetingRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/meeting/MeetingRepository.java
@@ -12,6 +12,9 @@ public interface MeetingRepository extends Repository<Meeting, Long> {
 
     Optional<Meeting> findById(final Long id);
 
+    @Query("select m from Meeting m join fetch m.participants p where m.id = :id")
+    Optional<Meeting> findMeetingAndParticipantsById(@Param("id") final Long id);
+
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("delete from Meeting m where m.id = :id")
     void deleteById(@Param("id") final Long id);

--- a/backend/src/main/java/com/woowacourse/moragora/domain/meeting/MeetingRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/meeting/MeetingRepository.java
@@ -10,6 +10,8 @@ public interface MeetingRepository extends Repository<Meeting, Long> {
 
     Meeting save(final Meeting meeting);
 
+    Boolean existsById(final Long id);
+
     Optional<Meeting> findById(final Long id);
 
     @Query("select m from Meeting m join fetch m.participants p where m.id = :id")

--- a/backend/src/main/java/com/woowacourse/moragora/domain/participant/Participant.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/participant/Participant.java
@@ -1,5 +1,6 @@
 package com.woowacourse.moragora.domain.participant;
 
+import com.woowacourse.moragora.domain.exception.BusinessException;
 import com.woowacourse.moragora.domain.meeting.Meeting;
 import com.woowacourse.moragora.domain.user.User;
 import javax.persistence.Column;
@@ -11,6 +12,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,6 +38,9 @@ public class Participant {
     @JoinColumn(name = "meeting_id")
     private Meeting meeting;
 
+    @Transient
+    private Long tardyCount;
+
     public Participant(final User user, final Meeting meeting, final boolean isMaster) {
         this.user = user;
         this.meeting = meeting;
@@ -52,5 +57,21 @@ public class Participant {
 
     public void updateIsMaster(final boolean isMaster) {
         this.isMaster = isMaster;
+    }
+
+    public boolean isSameParticipant(final Long userId) {
+        return user.isSameUser(userId);
+    }
+
+    public void allocateTardyCount(final Long tardyCount) {
+        this.tardyCount = tardyCount;
+    }
+
+    public Long getTardyCount() {
+        if (tardyCount == null) {
+            throw new BusinessException("지각 횟수가 할당되지 않았습니다.");
+        }
+
+        return tardyCount;
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/domain/participant/ParticipantAndCount.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/participant/ParticipantAndCount.java
@@ -1,0 +1,8 @@
+package com.woowacourse.moragora.domain.participant;
+
+public interface ParticipantAndCount {
+
+    Participant getParticipant();
+
+    Long getTardyCount();
+}

--- a/backend/src/main/java/com/woowacourse/moragora/domain/query/QueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/query/QueryRepository.java
@@ -11,9 +11,11 @@ import org.springframework.data.repository.query.Param;
 
 public interface QueryRepository extends Repository<Meeting, Long> {
 
-    @Query("select p as participant, (select count(a) from Attendance a inner join a.event e "
-            + "  where a.participant.id = p.id and a.status = 'TARDY' and a.disabled = false and e.date <= :date) "
-            + "  as tardyCount "
+    @Query("select p as participant, "
+            +   "(select count(a) "
+            +   "from Attendance a inner join a.event e "
+            +   "where a.participant.id = p.id and a.status = 'TARDY' and a.disabled = false and e.date <= :date) "
+            +   "as tardyCount "
             + "from Participant p join fetch p.user "
             + "where p in :participants")
     List<ParticipantAndCount> countParticipantsTardy(@Param("participants") final List<Participant> participants,

--- a/backend/src/main/java/com/woowacourse/moragora/domain/query/QueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/query/QueryRepository.java
@@ -1,0 +1,21 @@
+package com.woowacourse.moragora.domain.query;
+
+import com.woowacourse.moragora.domain.meeting.Meeting;
+import com.woowacourse.moragora.domain.participant.Participant;
+import com.woowacourse.moragora.domain.participant.ParticipantAndCount;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+public interface QueryRepository extends Repository<Meeting, Long> {
+
+    @Query("select p as participant, (select count(a) from Attendance a inner join a.event e "
+            + "  where a.participant.id = p.id and a.status = 'TARDY' and a.disabled = false and e.date <= :date) "
+            + "  as tardyCount "
+            + "from Participant p join fetch p.user "
+            + "where p in :participants")
+    List<ParticipantAndCount> countParticipantsTardy(@Param("participants") final List<Participant> participants,
+                                                     @Param("date") final LocalDate date);
+}

--- a/backend/src/main/java/com/woowacourse/moragora/domain/user/User.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/user/User.java
@@ -87,6 +87,10 @@ public class User {
         this.password = newPassword;
     }
 
+    public boolean isSameUser(final Long userId) {
+        return id.equals(userId);
+    }
+
     private void validateEmail(final String email) {
         final Matcher matcher = PATTERN_EMAIL.matcher(email);
         if (!matcher.matches()) {

--- a/backend/src/main/java/com/woowacourse/moragora/domain/user/UserRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/user/UserRepository.java
@@ -20,4 +20,6 @@ public interface UserRepository extends Repository<User, Long> {
     List<User> findByNicknameOrEmailLike(@Param("keyword") final String keyword);
 
     void delete(final User user);
+
+    boolean existsById(final Long userId);
 }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/response/meeting/MeetingResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/response/meeting/MeetingResponse.java
@@ -1,8 +1,10 @@
 package com.woowacourse.moragora.dto.response.meeting;
 
 import com.woowacourse.moragora.domain.meeting.Meeting;
+import com.woowacourse.moragora.domain.participant.Participant;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -18,7 +20,6 @@ public class MeetingResponse {
     private final long attendedEventCount;
     private final Boolean isLoginUserMaster;
     private final Boolean isCoffeeTime;
-    private final Boolean isActive;
     private final List<ParticipantResponse> users;
 
     @Builder
@@ -27,30 +28,28 @@ public class MeetingResponse {
                            final long attendedEventCount,
                            final Boolean isLoginUserMaster,
                            final Boolean isCoffeeTime,
-                           final Boolean isActive,
                            final List<ParticipantResponse> participantResponses) {
         this.id = id;
         this.name = name;
         this.attendedEventCount = attendedEventCount;
         this.isLoginUserMaster = isLoginUserMaster;
         this.isCoffeeTime = isCoffeeTime;
-        this.isActive = isActive;
         this.users = participantResponses;
     }
 
-    public static MeetingResponse from(final Meeting meeting,
-                                       final long attendedEventCount,
-                                       final boolean isLoginUserMaster,
-                                       final boolean isCoffeeTime,
-                                       final boolean isActive,
-                                       final List<ParticipantResponse> participantResponses) {
+    public static MeetingResponse of(final Meeting meeting,
+                                     final long attendedEventCount,
+                                     final Participant participant) {
+        final List<ParticipantResponse> participantResponses = meeting.getParticipants().stream()
+                .map(ParticipantResponse::from)
+                .collect(Collectors.toList());
+
         return new MeetingResponse(
                 meeting.getId(),
                 meeting.getName(),
                 attendedEventCount,
-                isLoginUserMaster,
-                isCoffeeTime,
-                isActive,
+                participant.getIsMaster(),
+                meeting.isTardyStackFull(),
                 participantResponses
         );
     }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/response/meeting/MeetingResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/response/meeting/MeetingResponse.java
@@ -39,7 +39,7 @@ public class MeetingResponse {
 
     public static MeetingResponse of(final Meeting meeting,
                                      final long attendedEventCount,
-                                     final Participant participant) {
+                                     final Participant loginParticipant) {
         final List<ParticipantResponse> participantResponses = meeting.getParticipants().stream()
                 .map(ParticipantResponse::from)
                 .collect(Collectors.toList());
@@ -48,7 +48,7 @@ public class MeetingResponse {
                 meeting.getId(),
                 meeting.getName(),
                 attendedEventCount,
-                participant.getIsMaster(),
+                loginParticipant.getIsMaster(),
                 meeting.isTardyStackFull(),
                 participantResponses
         );

--- a/backend/src/main/java/com/woowacourse/moragora/dto/response/meeting/ParticipantResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/response/meeting/ParticipantResponse.java
@@ -20,22 +20,23 @@ public class ParticipantResponse {
     public ParticipantResponse(final Long id,
                                final String email,
                                final String nickname,
-                               final int tardyCount,
+                               final long tardyCount,
                                final boolean isMaster) {
         this.id = id;
         this.email = email;
         this.nickname = nickname;
-        this.tardyCount = tardyCount;
+        this.tardyCount = (int) tardyCount;
         this.isMaster = isMaster;
     }
 
-    public static ParticipantResponse of(final Participant participant, final int tardyCount) {
+    public static ParticipantResponse from(final Participant participant) {
         final User user = participant.getUser();
+
         return new ParticipantResponse(
                 user.getId(),
                 user.getEmail(),
                 user.getNickname(),
-                tardyCount,
+                participant.getTardyCount(),
                 participant.getIsMaster());
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
@@ -14,8 +14,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
-import com.woowacourse.moragora.application.AttendanceScheduler;
-import com.woowacourse.moragora.application.ServerTimeManager;
 import com.woowacourse.moragora.domain.event.Event;
 import com.woowacourse.moragora.domain.meeting.Meeting;
 import com.woowacourse.moragora.domain.user.User;
@@ -30,8 +28,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 
 @DisplayName("모임 관련 기능")
@@ -90,7 +86,6 @@ class MeetingAcceptanceTest extends AcceptanceTest {
                 .body("attendedEventCount", equalTo(0))
                 .body("isLoginUserMaster", equalTo(true))
                 .body("isCoffeeTime", equalTo(false))
-                .body("isActive", equalTo(false))
                 .body("users.id", equalTo(ids))
                 .body("users.nickname", equalTo(getNicknamesIncludingMaster()))
                 .body("users.email", equalTo(getEmailsIncludingMaster()));

--- a/backend/src/test/java/com/woowacourse/moragora/application/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/application/MeetingServiceTest.java
@@ -6,6 +6,7 @@ import static com.woowacourse.moragora.support.fixture.EventFixtures.EVENT3;
 import static com.woowacourse.moragora.support.fixture.EventFixtures.EVENT4;
 import static com.woowacourse.moragora.support.fixture.MeetingFixtures.MORAGORA;
 import static com.woowacourse.moragora.support.fixture.MeetingFixtures.TEATIME;
+import static com.woowacourse.moragora.support.fixture.UserFixtures.AZPI;
 import static com.woowacourse.moragora.support.fixture.UserFixtures.KUN;
 import static com.woowacourse.moragora.support.fixture.UserFixtures.MASTER;
 import static com.woowacourse.moragora.support.fixture.UserFixtures.PHILLZ;
@@ -168,67 +169,34 @@ class MeetingServiceTest {
     void findById() {
         // given
         final Meeting meeting = dataSupport.saveMeeting(MORAGORA.create());
-        final User user = dataSupport.saveUser(KUN.create());
-        final Participant participant = dataSupport.saveParticipant(user, meeting, true);
+        final User user1 = dataSupport.saveUser(KUN.create());
+        final User user2 = dataSupport.saveUser(SUN.create());
+        final User user3 = dataSupport.saveUser(AZPI.create());
+        final Participant participant1 = dataSupport.saveParticipant(user1, meeting, true);
+        final Participant participant2 = dataSupport.saveParticipant(user2, meeting, false);
+        final Participant participant3 = dataSupport.saveParticipant(user3, meeting, false);
         final Event event1 = dataSupport.saveEvent(EVENT1.create(meeting));
         final Event event2 = dataSupport.saveEvent(EVENT2.create(meeting));
         final Event event3 = dataSupport.saveEvent(EVENT3.create(meeting));
-        dataSupport.saveAttendance(participant, event1, Status.TARDY);
-        dataSupport.saveAttendance(participant, event2, Status.TARDY);
-        dataSupport.saveAttendance(participant, event3, Status.TARDY);
-
-        final MeetingResponse expectedMeetingResponse = MeetingResponse.builder()
-                .id(meeting.getId())
-                .name(meeting.getName())
-                .participantResponses(List.of(ParticipantResponse.of(participant, 3)))
-                .attendedEventCount(3)
-                .isCoffeeTime(true)
-                .isActive(false)
-                .isLoginUserMaster(true)
-                .build();
+        dataSupport.saveAttendance(participant1, event1, Status.TARDY);
+        dataSupport.saveAttendance(participant1, event2, Status.TARDY);
+        dataSupport.saveAttendance(participant1, event3, Status.TARDY);
+        dataSupport.saveAttendance(participant2, event3, Status.TARDY);
+        dataSupport.saveAttendance(participant3, event3, Status.TARDY);
 
         final LocalDateTime dateTime = LocalDateTime.of(2022, 8, 4, 10, 6);
         serverTimeManager.refresh(dateTime);
 
         // when
-        final MeetingResponse response = meetingService.findById(meeting.getId(), user.getId());
-
-        // then
-        assertThat(response).usingRecursiveComparison()
-                .ignoringFields("users")
-                .isEqualTo(expectedMeetingResponse);
-    }
-
-    @DisplayName("id로 모임 상세 정보를 조회한다_당일 출석부가 없는 경우 추가 후 조회한다.")
-    @Test
-    void findById_putAttendanceIfAbsent() {
-        // given
-        final Meeting meeting = dataSupport.saveMeeting(MORAGORA.create());
-        final User user = dataSupport.saveUser(KUN.create());
-        final Participant participant = dataSupport.saveParticipant(user, meeting);
-
-        final Event event1 = dataSupport.saveEvent(EVENT1.create(meeting));
-        final Event event2 = dataSupport.saveEvent(EVENT2.create(meeting));
-        final Event event3 = dataSupport.saveEvent(EVENT3.create(meeting));
-        dataSupport.saveAttendance(participant, event1, Status.TARDY);
-        dataSupport.saveAttendance(participant, event2, Status.TARDY);
-        dataSupport.saveAttendance(participant, event3, Status.TARDY);
-
+        final MeetingResponse response = meetingService.findById(meeting.getId(), user1.getId());
         final MeetingResponse expectedMeetingResponse = MeetingResponse.builder()
                 .id(meeting.getId())
                 .name(meeting.getName())
-                .participantResponses(List.of(ParticipantResponse.of(participant, 3)))
+                .participantResponses(List.of())
                 .attendedEventCount(3)
                 .isCoffeeTime(true)
-                .isActive(false)
-                .isLoginUserMaster(false)
+                .isLoginUserMaster(true)
                 .build();
-
-        final LocalDateTime dateTime = LocalDateTime.of(2022, 8, 4, 10, 0);
-        serverTimeManager.refresh(dateTime);
-
-        // when
-        final MeetingResponse response = meetingService.findById(meeting.getId(), user.getId());
 
         // then
         assertThat(response).usingRecursiveComparison()
@@ -269,7 +237,6 @@ class MeetingServiceTest {
                 .participantResponses(usersResponse)
                 .attendedEventCount(1)
                 .isCoffeeTime(false)
-                .isActive(true)
                 .isLoginUserMaster(true)
                 .build();
 
@@ -317,7 +284,6 @@ class MeetingServiceTest {
                 .participantResponses(usersResponse)
                 .attendedEventCount(1)
                 .isCoffeeTime(true)
-                .isActive(false)
                 .isLoginUserMaster(true)
                 .build();
 
@@ -348,7 +314,6 @@ class MeetingServiceTest {
                 .name(meeting.getName())
                 .attendedEventCount(1)
                 .isCoffeeTime(false)
-                .isActive(true)
                 .isLoginUserMaster(true)
                 .build();
 
@@ -379,7 +344,6 @@ class MeetingServiceTest {
                 .name(meeting.getName())
                 .attendedEventCount(1)
                 .isCoffeeTime(false)
-                .isActive(false)
                 .isLoginUserMaster(true)
                 .build();
 

--- a/backend/src/test/java/com/woowacourse/moragora/domain/meeting/MeetingRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/domain/meeting/MeetingRepositoryTest.java
@@ -1,18 +1,31 @@
 package com.woowacourse.moragora.domain.meeting;
 
 import static com.woowacourse.moragora.support.fixture.MeetingFixtures.MORAGORA;
+import static com.woowacourse.moragora.support.fixture.UserFixtures.KUN;
+import static com.woowacourse.moragora.support.fixture.UserFixtures.SUN;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.moragora.domain.participant.Participant;
+import com.woowacourse.moragora.domain.user.User;
+import com.woowacourse.moragora.support.DataSupport;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
-@DataJpaTest
+
+@Import(DataSupport.class)
+@DataJpaTest(showSql = false)
 class MeetingRepositoryTest {
 
     @Autowired
     private MeetingRepository meetingRepository;
+
+    @Autowired
+    private DataSupport dataSupport;
 
     @DisplayName("미팅 방을 저장한다.")
     @Test
@@ -37,5 +50,27 @@ class MeetingRepositoryTest {
 
         // then
         assertThat(foundMeeting).isNotNull();
+    }
+
+    @DisplayName("미팅 정보와 모든 참가자 정보를 조회한다.")
+    @Test
+    void findMeetingAndParticipantsById() {
+        // given
+        final User user1 = dataSupport.saveUser(SUN.create());
+        final User user2 = dataSupport.saveUser(KUN.create());
+        final Meeting meeting = dataSupport.saveMeeting(MORAGORA.create());
+        final Participant participant1 = dataSupport.saveParticipant(user1, meeting);
+        final Participant participant2 = dataSupport.saveParticipant(user2, meeting);
+        participant1.mapMeeting(meeting);
+        participant2.mapMeeting(meeting);
+
+        // when
+        final Meeting foundMeeting = meetingRepository.findMeetingAndParticipantsById(meeting.getId()).get();
+
+        // then
+        assertAll(
+                () -> assertThat(foundMeeting).isEqualTo(meeting),
+                () -> assertThat(meeting.getParticipants()).containsAll(List.of(participant1, participant2))
+        );
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/domain/meeting/MeetingTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/domain/meeting/MeetingTest.java
@@ -1,9 +1,16 @@
 package com.woowacourse.moragora.domain.meeting;
 
+import static com.woowacourse.moragora.domain.user.Provider.GOOGLE;
+import static com.woowacourse.moragora.domain.user.password.EncodedPassword.fromRawValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.moragora.domain.participant.Participant;
+import com.woowacourse.moragora.domain.participant.ParticipantAndCount;
+import com.woowacourse.moragora.domain.user.User;
 import com.woowacourse.moragora.exception.global.InvalidFormatException;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,5 +59,110 @@ class MeetingTest {
         // when, then
         assertThatThrownBy(() -> meeting.updateName(name))
                 .isInstanceOf(InvalidFormatException.class);
+    }
+
+    @DisplayName("userId로 참가자를 찾는다.")
+    @Test
+    void findParticipant() {
+        // given
+        final Meeting meeting = new Meeting(1L, "체크메이트");
+        final User user = new User(1L, "sun@gmail.com", fromRawValue("asdf1234!"), "sun", GOOGLE);
+        final Participant participant = new Participant(user, meeting, true);
+        participant.mapMeeting(meeting);
+
+        // when
+        final Participant foundParticipant = meeting.findParticipant(1L).get();
+
+        // then
+        assertThat(foundParticipant).isEqualTo(participant);
+    }
+
+    @DisplayName("참가자들의 결석 횟수를 할당한다.")
+    @Test
+    void allocateParticipantsTardyCount() {
+        // given
+        final Meeting meeting = new Meeting(1L, "체크메이트");
+        final User user = new User(1L, "sun@gmail.com", fromRawValue("asdf1234!"), "sun", GOOGLE);
+        final Participant participant = new Participant(user, meeting, true);
+        ParticipantAndCount participantAndCount = new ParticipantAndCount() {
+            @Override
+            public Participant getParticipant() {
+                return participant;
+            }
+
+            @Override
+            public Long getTardyCount() {
+                return 5L;
+            }
+        };
+
+        // when
+        meeting.allocateParticipantsTardyCount(List.of(participantAndCount));
+
+        // then
+        assertThat(participant.getTardyCount()).isEqualTo(5);
+    }
+
+    @DisplayName("모임의 지각 횟수가 다 채워졌다면 True를 반환한다.")
+    @Test
+    void isTardyStackFull() {
+        // given
+        final Meeting meeting = new Meeting(1L, "체크메이트");
+        final User user1 = new User(1L, "sun@gmail.com", fromRawValue("asdf1234!"), "sun", GOOGLE);
+        final User user2 = new User(2L, "kun@gmail.com", fromRawValue("asdf1234!"), "kun", GOOGLE);
+        final Participant participant1 = new Participant(user1, meeting, true);
+        final Participant participant2 = new Participant(user2, meeting, false);
+        participant1.mapMeeting(meeting);
+        participant2.mapMeeting(meeting);
+        participant1.allocateTardyCount(1L);
+        participant2.allocateTardyCount(1L);
+
+        // when
+        final Boolean isTardyStackFull = meeting.isTardyStackFull();
+
+        // then
+        assertThat(isTardyStackFull).isTrue();
+    }
+
+    @DisplayName("모임의 지각 횟수가 다 채워지지 않았다면 False를 반환한다.")
+    @Test
+    void isTardyStackFull_returnsFalse_tardyStackLessThanParticipantsSize() {
+        // given
+        final Meeting meeting = new Meeting(1L, "체크메이트");
+        final User user1 = new User(1L, "sun@gmail.com", fromRawValue("asdf1234!"), "sun", GOOGLE);
+        final User user2 = new User(2L, "kun@gmail.com", fromRawValue("asdf1234!"), "kun", GOOGLE);
+        final Participant participant1 = new Participant(user1, meeting, true);
+        final Participant participant2 = new Participant(user2, meeting, false);
+        participant1.mapMeeting(meeting);
+        participant2.mapMeeting(meeting);
+        participant1.allocateTardyCount(1L);
+        participant2.allocateTardyCount(0L);
+
+        // when
+        final Boolean isTardyStackFull = meeting.isTardyStackFull();
+
+        // then
+        assertThat(isTardyStackFull).isFalse();
+    }
+
+    @DisplayName("모임 참가자들의 지각 횟수의 총 합을 계산한다.")
+    @Test
+    void calculateTardy() {
+        // given
+        final Meeting meeting = new Meeting(1L, "체크메이트");
+        final User user1 = new User(1L, "sun@gmail.com", fromRawValue("asdf1234!"), "sun", GOOGLE);
+        final User user2 = new User(2L, "kun@gmail.com", fromRawValue("asdf1234!"), "kun", GOOGLE);
+        final Participant participant1 = new Participant(user1, meeting, true);
+        final Participant participant2 = new Participant(user2, meeting, false);
+        participant1.mapMeeting(meeting);
+        participant2.mapMeeting(meeting);
+        participant1.allocateTardyCount(5L);
+        participant2.allocateTardyCount(3L);
+
+        // when
+        final long totalTardyCount = meeting.calculateTardy();
+
+        // then
+        assertThat(totalTardyCount).isEqualTo(8);
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/domain/participant/ParticipantTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/domain/participant/ParticipantTest.java
@@ -1,13 +1,19 @@
 package com.woowacourse.moragora.domain.participant;
 
+import static com.woowacourse.moragora.domain.user.Provider.GOOGLE;
+import static com.woowacourse.moragora.domain.user.password.EncodedPassword.fromRawValue;
 import static com.woowacourse.moragora.support.fixture.MeetingFixtures.MORAGORA;
 import static com.woowacourse.moragora.support.fixture.UserFixtures.KUN;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.moragora.domain.exception.BusinessException;
 import com.woowacourse.moragora.domain.meeting.Meeting;
 import com.woowacourse.moragora.domain.user.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class ParticipantTest {
 
@@ -42,5 +48,90 @@ class ParticipantTest {
 
         // then
         assertThat(meeting.getParticipants()).hasSize(1);
+    }
+
+    @DisplayName("유저 id로 같은 참가자인지 확인한다.")
+    @ParameterizedTest
+    @CsvSource(value = {"1,true", "2,false"})
+    void isSameParticipant(final long userId, final boolean actual) {
+        // given
+        final Meeting meeting = MORAGORA.create();
+        final User user = User.builder()
+                .id(1L)
+                .nickname("sun")
+                .email("sun@gmail.com")
+                .password(fromRawValue("1234asdf!"))
+                .provider(GOOGLE)
+                .build();
+        final Participant participant = new Participant(user, meeting, true);
+
+        // when
+        final boolean expected = participant.isSameParticipant(userId);
+
+        // then
+        assertThat(expected).isEqualTo(actual);
+    }
+
+    @DisplayName("참가자의 지각 횟수를 할당한다.")
+    @Test
+    void allocateTardyCount() {
+        // given
+        final Meeting meeting = MORAGORA.create();
+        final User user = User.builder()
+                .id(1L)
+                .nickname("sun")
+                .email("sun@gmail.com")
+                .password(fromRawValue("1234asdf!"))
+                .provider(GOOGLE)
+                .build();
+        final Participant participant = new Participant(user, meeting, true);
+
+        // when
+        participant.allocateTardyCount(5L);
+
+        // then
+        assertThat(participant.getTardyCount()).isEqualTo(5);
+    }
+
+    @DisplayName("참가자의 지각 횟수를 반환한다.")
+    @Test
+    void getTardyCount() {
+        // given
+        final Meeting meeting = MORAGORA.create();
+        final User user = User.builder()
+                .id(1L)
+                .nickname("sun")
+                .email("sun@gmail.com")
+                .password(fromRawValue("1234asdf!"))
+                .provider(GOOGLE)
+                .build();
+        final Participant participant = new Participant(user, meeting, true);
+        participant.allocateTardyCount(5L);
+
+        // when
+        final Long tardyCount = participant.getTardyCount();
+
+        // then
+        assertThat(tardyCount).isEqualTo(5);
+    }
+
+    @DisplayName("참가자의 지각 횟수를 반환한다.")
+    @Test
+    void getTardyCount_throwsException_ifNotAllocated() {
+        // given
+        final Meeting meeting = MORAGORA.create();
+        final User user = User.builder()
+                .id(1L)
+                .nickname("sun")
+                .email("sun@gmail.com")
+                .password(fromRawValue("1234asdf!"))
+                .provider(GOOGLE)
+                .build();
+        final Participant participant = new Participant(user, meeting, true);
+
+        // when, then
+        assertThatThrownBy(participant::getTardyCount)
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("지각 횟수가 할당되지 않았습니다.");
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/domain/participant/ParticipantTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/domain/participant/ParticipantTest.java
@@ -115,7 +115,7 @@ class ParticipantTest {
         assertThat(tardyCount).isEqualTo(5);
     }
 
-    @DisplayName("참가자의 지각 횟수를 반환한다.")
+    @DisplayName("참가자의 지각 횟수 할당하기 전에 사용하려하면 예외가 발생한다.")
     @Test
     void getTardyCount_throwsException_ifNotAllocated() {
         // given

--- a/backend/src/test/java/com/woowacourse/moragora/domain/query/QueryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/domain/query/QueryRepositoryTest.java
@@ -1,0 +1,70 @@
+package com.woowacourse.moragora.domain.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.moragora.domain.attendance.Status;
+import com.woowacourse.moragora.domain.event.Event;
+import com.woowacourse.moragora.domain.meeting.Meeting;
+import com.woowacourse.moragora.domain.participant.Participant;
+import com.woowacourse.moragora.domain.participant.ParticipantAndCount;
+import com.woowacourse.moragora.domain.user.User;
+import com.woowacourse.moragora.support.DataSupport;
+import com.woowacourse.moragora.support.fixture.EventFixtures;
+import com.woowacourse.moragora.support.fixture.MeetingFixtures;
+import com.woowacourse.moragora.support.fixture.UserFixtures;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@Import(DataSupport.class)
+@DataJpaTest(showSql = false)
+class QueryRepositoryTest {
+
+    @Autowired
+    private QueryRepository queryRepository;
+
+    @Autowired
+    private DataSupport dataSupport;
+
+
+    @DisplayName("참가자 정보와 참가자의 활성화된 총 지각 횟수를 반환한다.")
+    @Test
+    void countParticipantsTardy() {
+        // given
+        final Meeting meeting = dataSupport.saveMeeting(MeetingFixtures.MORAGORA.create());
+        final User user1 = dataSupport.saveUser(UserFixtures.SUN.create());
+        final User user2 = dataSupport.saveUser(UserFixtures.PHILLZ.create());
+        final User user3 = dataSupport.saveUser(UserFixtures.AZPI.create());
+        final Participant participant1 = dataSupport.saveParticipant(user1, meeting);
+        final Participant participant2 = dataSupport.saveParticipant(user2, meeting);
+        final Participant participant3 = dataSupport.saveParticipant(user3, meeting);
+        final Event event = dataSupport.saveEvent(EventFixtures.EVENT1.create(meeting));
+        dataSupport.saveAttendance(participant1, event, Status.TARDY);
+        dataSupport.saveAttendance(participant2, event, Status.TARDY);
+        dataSupport.saveAttendance(participant3, event, Status.NONE);
+
+        // when
+        final List<ParticipantAndCount> participantAndCounts = queryRepository
+                .countParticipantsTardy(List.of(participant1, participant2, participant3), LocalDate.now());
+
+        // then
+        final long expected = participantAndCounts.stream()
+                .mapToLong(ParticipantAndCount::getTardyCount)
+                .sum();
+        final List<Participant> participants = participantAndCounts.stream()
+                .map(ParticipantAndCount::getParticipant)
+                .collect(Collectors.toList());
+
+        assertAll(
+                () -> assertThat(participantAndCounts).hasSize(3),
+                () -> assertThat(expected).isEqualTo(2L),
+                () -> assertThat(participants).containsAll(List.of(participant1, participant2, participant3))
+        );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/moragora/domain/user/UserTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/domain/user/UserTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.moragora.domain.user;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -95,5 +96,24 @@ class UserTest {
         // when, then
         assertThatThrownBy(() -> user.updateNickname(nickname))
                 .isInstanceOf(InvalidFormatException.class);
+    }
+
+    @DisplayName("id로 같은 유저인지 확인한다.")
+    @Test
+    void isSameUser() {
+        // given
+        final User user = User.builder()
+                .id(1L)
+                .nickname("sun")
+                .email("sun@gmail.com")
+                .password(EncodedPassword.fromRawValue("qwerasdf123!"))
+                .provider(Provider.GOOGLE)
+                .build();
+
+        // when
+        final boolean expected = user.isSameUser(1L);
+
+        // then
+        assertThat(expected).isTrue();
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/presentation/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/presentation/MeetingControllerTest.java
@@ -231,7 +231,6 @@ class MeetingControllerTest extends ControllerTest {
                         .value("유저가 존재하지 않습니다."));
     }
 
-    // TODO userResponse 테스트 작성
     @DisplayName("단일 미팅 방을 조회한다.")
     @Test
     void findOne() throws Exception {
@@ -245,7 +244,7 @@ class MeetingControllerTest extends ControllerTest {
         final int attendanceCount = 0;
         final boolean isMaster = true;
         final MeetingResponse meetingResponse =
-                new MeetingResponse(id, name, attendanceCount, isMaster, false, true, participantResponses);
+                new MeetingResponse(id, name, attendanceCount, isMaster, false, participantResponses);
 
         final Long loginId = validateToken("1");
         given(meetingService.findById(eq(1L), eq(loginId)))
@@ -259,7 +258,6 @@ class MeetingControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.id", equalTo(1)))
                 .andExpect(jsonPath("$.name", equalTo("모임1")))
                 .andExpect(jsonPath("$.attendedEventCount", equalTo(0)))
-                .andExpect(jsonPath("$.isActive", equalTo(true)))
                 .andExpect(jsonPath("$.isLoginUserMaster", equalTo(true)))
                 .andExpect(jsonPath("$.isCoffeeTime", equalTo(false)))
                 .andExpect(jsonPath("$.users[*].id", containsInAnyOrder(1, 2)))
@@ -274,7 +272,6 @@ class MeetingControllerTest extends ControllerTest {
                                 fieldWithPath("name").type(JsonFieldType.STRING).description(name),
                                 fieldWithPath("attendedEventCount").type(JsonFieldType.NUMBER)
                                         .description(attendanceCount),
-                                fieldWithPath("isActive").type(JsonFieldType.BOOLEAN).description(true),
                                 fieldWithPath("isLoginUserMaster").type(JsonFieldType.BOOLEAN).description(isMaster),
                                 fieldWithPath("isCoffeeTime").type(JsonFieldType.BOOLEAN).description(false),
                                 fieldWithPath("users[].id").type(JsonFieldType.NUMBER).description(1L),


### PR DESCRIPTION
<!--Close #issue_number를 작성한다.-->
Close #500

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/meeting-findbyid -> dev

## 요구사항
- isActive 필드 제거
- 코드 리팩토링
- 테스트 코드 추가 및 수정

## 변경사항
- JPA 최적화 - 14개 -> 3개의 쿼리로 리팩토링
- 불필요한 fIndBy 보다 Exists로 존재여부 확인하도록 수정

## [Optional] 논의하고 싶은 내용

