### PR TITLE
[BE] 나의 미팅 조회 :: 리펙터링, 쿼리최적화

### DIFF
--- a/backend/src/main/java/com/woowacourse/moragora/application/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/MeetingService.java
@@ -181,13 +181,7 @@ public class MeetingService {
             final LocalTime attendanceClosedTime = upcomingEvent.getCloseTime(serverTimeManager);
             eventResponse = EventResponse.of(upcomingEvent, attendanceOpenTime, attendanceClosedTime);
         }
-        return new MyMeetingResponse(
-                meeting.getId(), meeting.getName(),
-                meeting.getTardyCount(), meeting.isMaster(userId),
-                meeting.isTardyStackFull(),
-                isActive,
-                eventResponse
-        );
+        return MyMeetingResponse.of(meeting, userId, isActive, eventResponse);
     }
 
     /**

--- a/backend/src/main/java/com/woowacourse/moragora/application/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/MeetingService.java
@@ -104,7 +104,8 @@ public class MeetingService {
         return new MyMeetingsResponse(getMyMeetingsResponse(userId, meetings, today));
     }
 
-    private List<MyMeetingResponse> getMyMeetingsResponse(final Long userId, final List<Meeting> meetings, final LocalDate today) {
+    private List<MyMeetingResponse> getMyMeetingsResponse(final Long userId, final List<Meeting> meetings,
+                                                          final LocalDate today) {
         final List<MyMeetingResponse> myMeetingResponses = new ArrayList<>();
         for (final Meeting meeting : meetings) {
             final List<ParticipantAndCount> participantAndCounts =
@@ -132,10 +133,8 @@ public class MeetingService {
             eventResponse = EventResponse.of(upcomingEvent, attendanceOpenTime, attendanceClosedTime);
         }
         return new MyMeetingResponse(
-                meeting.getId(),
-                meeting.getName(),
-                meeting.getTardyCount(),
-                meeting.isMaster(userId),
+                meeting.getId(), meeting.getName(),
+                meeting.getTardyCount(), meeting.isMaster(userId),
                 meeting.isTardyStackFull(),
                 isActive,
                 eventResponse

--- a/backend/src/main/java/com/woowacourse/moragora/application/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/MeetingService.java
@@ -85,7 +85,7 @@ public class MeetingService {
 
         final List<ParticipantAndCount> participantAndCounts = queryRepository
                 .countParticipantsTardy(meeting.getParticipants());
-        meeting.allocateParticipantsTardyCount(participantAndCounts);
+        meeting.allocateTardyCount(participantAndCounts);
 
         final long attendedEventCount = eventRepository.countByMeetingIdAndDateLessThanEqual(meetingId, today);
         final Participant loginParticipant = meeting.findParticipant(loginId)
@@ -157,9 +157,7 @@ public class MeetingService {
         for (final Meeting meeting : meetings) {
             final List<ParticipantAndCount> participantAndCounts =
                     queryRepository.countParticipantsTardy(meeting.getParticipants());
-            meeting.allocateParticipantsTardyCount(participantAndCounts);
-            meeting.isTardyStackFull();
-            meeting.isMaster(userId);
+            meeting.allocateTardyCount(participantAndCounts);
             final Event upcomingEvent = eventRepository
                     .findFirstByMeetingIdAndDateGreaterThanEqualOrderByDate(meeting.getId(), today)
                     .orElse(null);

--- a/backend/src/main/java/com/woowacourse/moragora/application/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/MeetingService.java
@@ -95,7 +95,7 @@ public class MeetingService {
     }
 
     public MyMeetingsResponse findAllByUserId(final Long userId) {
-        final List<Meeting> meetings = queryRepository.findMeetingByUserId(userId);
+        final List<Meeting> meetings = meetingRepository.findMeetingParticipantsByUserId(userId);
         final LocalDate today = serverTimeManager.getDate();
         return new MyMeetingsResponse(getMyMeetingsResponse(userId, meetings, today));
     }

--- a/backend/src/main/java/com/woowacourse/moragora/application/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/MeetingService.java
@@ -84,7 +84,7 @@ public class MeetingService {
                 .orElseThrow(MeetingNotFoundException::new);
 
         final List<ParticipantAndCount> participantAndCounts = queryRepository
-                .countParticipantsTardy(meeting.getParticipants());
+                .countParticipantsTardyDto(meeting.getParticipants());
         meeting.allocateTardyCount(participantAndCounts);
 
         final long attendedEventCount = eventRepository.countByMeetingIdAndDateLessThanEqual(meetingId, today);
@@ -156,7 +156,7 @@ public class MeetingService {
         final List<MyMeetingResponse> myMeetingResponses = new ArrayList<>();
         for (final Meeting meeting : meetings) {
             final List<ParticipantAndCount> participantAndCounts =
-                    queryRepository.countParticipantsTardy(meeting.getParticipants());
+                    queryRepository.countParticipantsTardyDto(meeting.getParticipants());
             meeting.allocateTardyCount(participantAndCounts);
             final Event upcomingEvent = eventRepository
                     .findFirstByMeetingIdAndDateGreaterThanEqualOrderByDate(meeting.getId(), today)

--- a/backend/src/main/java/com/woowacourse/moragora/application/ServerTimeManager.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/ServerTimeManager.java
@@ -12,8 +12,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class ServerTimeManager {
 
-    private static final int ATTENDANCE_END_INTERVAL = 5;
     private static final int ATTENDANCE_START_INTERVAL = 30;
+    private static final int ATTENDANCE_END_INTERVAL = 5;
 
     private final DateTime dateTime;
 

--- a/backend/src/main/java/com/woowacourse/moragora/domain/attendance/ParticipantAttendances.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/attendance/ParticipantAttendances.java
@@ -13,7 +13,7 @@ public class ParticipantAttendances {
         this.values = values;
     }
 
-    public int countTardy() {
+    public Integer countTardy() {
         return (int) values.stream()
                 .filter(Attendance::isEnabled)
                 .filter(Attendance::isTardy)

--- a/backend/src/main/java/com/woowacourse/moragora/domain/event/Event.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/event/Event.java
@@ -1,5 +1,6 @@
 package com.woowacourse.moragora.domain.event;
 
+import com.woowacourse.moragora.application.ServerTimeManager;
 import com.woowacourse.moragora.domain.meeting.Meeting;
 import com.woowacourse.moragora.exception.meeting.IllegalEntranceLeaveTimeException;
 import java.time.LocalDate;
@@ -96,5 +97,17 @@ public class Event {
         if (entranceTime.isAfter(leaveTime)) {
             throw new IllegalEntranceLeaveTimeException();
         }
+    }
+
+    public boolean isActive(final LocalDate today, final ServerTimeManager serverTimeManager) {
+        return isSameDate(today) && serverTimeManager.isAttendanceOpen(startTime);
+    }
+
+    public LocalTime getOpenTime(final ServerTimeManager serverTimeManager) {
+        return serverTimeManager.calculateOpenTime(startTime);
+    }
+
+    public LocalTime getCloseTime(final ServerTimeManager serverTimeManager) {
+        return serverTimeManager.calculateAttendanceCloseTime(startTime);
     }
 }

--- a/backend/src/main/java/com/woowacourse/moragora/domain/meeting/Meeting.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/meeting/Meeting.java
@@ -67,8 +67,9 @@ public class Meeting {
                 .collect(Collectors.toUnmodifiableList());
     }
 
-    public void allocateParticipantsTardyCount(final List<ParticipantAndCount> participantAndCounts) {
+    public void allocateTardyCount(final List<ParticipantAndCount> participantAndCounts) {
         participantAndCounts.forEach(it -> it.getParticipant().allocateTardyCount(it.getTardyCount()));
+        calculateTardy();
     }
 
     public Boolean isTardyStackFull() {

--- a/backend/src/main/java/com/woowacourse/moragora/domain/meeting/Meeting.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/meeting/Meeting.java
@@ -67,12 +67,6 @@ public class Meeting {
                 .collect(Collectors.toUnmodifiableList());
     }
 
-    public Optional<Participant> findParticipant(final Long userId) {
-        return participants.stream()
-                .filter(it -> it.isSameParticipant(userId))
-                .findAny();
-    }
-
     public void allocateParticipantsTardyCount(final List<ParticipantAndCount> participantAndCounts) {
         participantAndCounts.forEach(it -> it.getParticipant().allocateTardyCount(it.getTardyCount()));
     }
@@ -81,7 +75,13 @@ public class Meeting {
         return calculateTardy() >= participants.size();
     }
 
-    public long calculateTardy() {
+    public Optional<Participant> findParticipant(final Long userId) {
+        return participants.stream()
+                .filter(it -> it.isSameParticipant(userId))
+                .findAny();
+    }
+
+    public Integer calculateTardy() {
         this.tardyCount = participants.stream()
                 .mapToInt(Participant::getTardyCount)
                 .sum();

--- a/backend/src/main/java/com/woowacourse/moragora/domain/meeting/MeetingRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/meeting/MeetingRepository.java
@@ -1,5 +1,6 @@
 package com.woowacourse.moragora.domain.meeting;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -16,6 +17,12 @@ public interface MeetingRepository extends Repository<Meeting, Long> {
 
     @Query("select m from Meeting m join fetch m.participants p where m.id = :id")
     Optional<Meeting> findMeetingAndParticipantsById(@Param("id") final Long id);
+
+    @Query("select m "
+            + " from Meeting m "
+            + " join fetch m.participants p "
+            + " where p.user.id = :userId")
+    List<Meeting> findMeetingParticipantsByUserId(@Param("userId") Long userId);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("delete from Meeting m where m.id = :id")

--- a/backend/src/main/java/com/woowacourse/moragora/domain/participant/Participant.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/participant/Participant.java
@@ -39,7 +39,7 @@ public class Participant {
     private Meeting meeting;
 
     @Transient
-    private Long tardyCount;
+    private Integer tardyCount;
 
     public Participant(final User user, final Meeting meeting, final boolean isMaster) {
         this.user = user;
@@ -63,11 +63,11 @@ public class Participant {
         return user.isSameUser(userId);
     }
 
-    public void allocateTardyCount(final Long tardyCount) {
+    public void allocateTardyCount(final Integer tardyCount) {
         this.tardyCount = tardyCount;
     }
 
-    public Long getTardyCount() {
+    public Integer getTardyCount() {
         if (tardyCount == null) {
             throw new BusinessException("지각 횟수가 할당되지 않았습니다.");
         }

--- a/backend/src/main/java/com/woowacourse/moragora/domain/participant/Participant.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/participant/Participant.java
@@ -13,6 +13,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+import javax.servlet.http.Part;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/backend/src/main/java/com/woowacourse/moragora/domain/participant/ParticipantAndCount.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/participant/ParticipantAndCount.java
@@ -4,5 +4,5 @@ public interface ParticipantAndCount {
 
     Participant getParticipant();
 
-    Long getTardyCount();
+    Integer getTardyCount();
 }

--- a/backend/src/main/java/com/woowacourse/moragora/domain/query/QueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/query/QueryRepository.java
@@ -3,7 +3,6 @@ package com.woowacourse.moragora.domain.query;
 import com.woowacourse.moragora.domain.meeting.Meeting;
 import com.woowacourse.moragora.domain.participant.Participant;
 import com.woowacourse.moragora.domain.participant.ParticipantAndCount;
-import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
@@ -13,22 +12,12 @@ public interface QueryRepository extends Repository<Meeting, Long> {
 
     @Query("select p as participant, "
             +   "(select count(a) "
-            +   "from Attendance a inner join a.event e "
-            +   "where a.participant.id = p.id and a.status = 'TARDY' and a.disabled = false and e.date <= :date) "
-            +   "as tardyCount "
-            + "from Participant p join fetch p.user "
-            + "where p in :participants")
-    List<ParticipantAndCount> countParticipantsTardy(@Param("participants") final List<Participant> participants,
-                                                     @Param("date") final LocalDate date);
-
-    @Query("select p as participant, "
-            +   "(select count(a) "
             +   "from Attendance a "
             +   "where a.participant.id = p.id and a.status = 'TARDY' and a.disabled = false) "
             +   "as tardyCount "
             + "from Participant p join fetch p.user "
             + "where p in :participants")
-    List<ParticipantAndCount> countParticipantsTardy_2(@Param("participants") final List<Participant> participants);
+    List<ParticipantAndCount> countParticipantsTardy(@Param("participants") final List<Participant> participants);
 
     @Query("select m "
             + " from Meeting m "

--- a/backend/src/main/java/com/woowacourse/moragora/domain/query/QueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/query/QueryRepository.java
@@ -19,9 +19,5 @@ public interface QueryRepository extends Repository<Meeting, Long> {
             + "where p in :participants")
     List<ParticipantAndCount> countParticipantsTardy(@Param("participants") final List<Participant> participants);
 
-    @Query("select m "
-            + " from Meeting m "
-            + " join fetch m.participants p "
-            + " where p.user.id = :userId")
-    List<Meeting> findMeetingByUserId(@Param("userId") Long userId);
+
 }

--- a/backend/src/main/java/com/woowacourse/moragora/domain/query/QueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/query/QueryRepository.java
@@ -17,5 +17,5 @@ public interface QueryRepository extends Repository<Meeting, Long> {
             +   "as tardyCount "
             + "from Participant p join fetch p.user "
             + "where p in :participants")
-    List<ParticipantAndCount> countParticipantsTardy(@Param("participants") final List<Participant> participants);
+    List<ParticipantAndCount> countParticipantsTardyDto(@Param("participants") final List<Participant> participants);
 }

--- a/backend/src/main/java/com/woowacourse/moragora/domain/query/QueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/query/QueryRepository.java
@@ -20,4 +20,19 @@ public interface QueryRepository extends Repository<Meeting, Long> {
             + "where p in :participants")
     List<ParticipantAndCount> countParticipantsTardy(@Param("participants") final List<Participant> participants,
                                                      @Param("date") final LocalDate date);
+
+    @Query("select p as participant, "
+            +   "(select count(a) "
+            +   "from Attendance a "
+            +   "where a.participant.id = p.id and a.status = 'TARDY' and a.disabled = false) "
+            +   "as tardyCount "
+            + "from Participant p join fetch p.user "
+            + "where p in :participants")
+    List<ParticipantAndCount> countParticipantsTardy_2(@Param("participants") final List<Participant> participants);
+
+    @Query("select m "
+            + " from Meeting m "
+            + " join fetch m.participants p "
+            + " where p.user.id = :userId")
+    List<Meeting> findMeetingByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/woowacourse/moragora/domain/query/QueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/query/QueryRepository.java
@@ -18,6 +18,4 @@ public interface QueryRepository extends Repository<Meeting, Long> {
             + "from Participant p join fetch p.user "
             + "where p in :participants")
     List<ParticipantAndCount> countParticipantsTardy(@Param("participants") final List<Participant> participants);
-
-
 }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/response/meeting/MyMeetingResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/response/meeting/MyMeetingResponse.java
@@ -43,8 +43,54 @@ public class MyMeetingResponse {
                                        final EventResponse upcomingEvent) {
 
         return new MyMeetingResponse(
-                meeting.getId(), meeting.getName(),
-                tardyCount, isLoginUserMaster, isCoffeeTime, isActive,
+                meeting.getId(),
+                meeting.getName(),
+                tardyCount,
+                isLoginUserMaster,
+                isCoffeeTime,
+                isActive,
+                upcomingEvent
+        );
+    }
+
+/*
+    public static MyMeetingResponse of(final Meeting meeting,
+                                       final Long userId
+                                       final boolean isActive,
+                                       final EventResponse upcomingEvent) {
+        return new MyMeetingResponse(
+                meeting.getId(),
+                meeting.getName(),
+                meeting.getTardyCount(),
+                meeting.isMaster(userId),
+                isActive,
+                upcomingEvent
+        );
+    }
+*/
+
+    /**
+     final Long id,
+     final String name,
+     final Integer tardyCount,
+     final Boolean isLoginUserMaster,
+     final Boolean isCoffeeTime,
+     final Boolean isActive,
+     final EventResponse upcomingEvent
+     */
+
+    public static MyMeetingResponse of(final Meeting meeting,
+                                       final Long userId,
+                                       final boolean isActive,
+                                       final EventResponse upcomingEvent) {
+
+        return new MyMeetingResponse(
+                meeting.getId(),
+                meeting.getName(),
+                meeting.getTardyCount(),
+                meeting.isMaster(userId),
+                meeting.isTardyStackFull(),
+                isActive,
                 upcomingEvent
         );
     }

--- a/backend/src/main/java/com/woowacourse/moragora/dto/response/meeting/MyMeetingResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/response/meeting/MyMeetingResponse.java
@@ -12,7 +12,7 @@ public class MyMeetingResponse {
 
     private final Long id;
     private final String name;
-    private final int tardyCount;
+    private final Integer tardyCount;
     private final Boolean isLoginUserMaster;
     private final Boolean isCoffeeTime;
     private final Boolean isActive;
@@ -21,7 +21,7 @@ public class MyMeetingResponse {
     @Builder
     public MyMeetingResponse(final Long id,
                              final String name,
-                             final int tardyCount,
+                             final Integer tardyCount,
                              final Boolean isLoginUserMaster,
                              final Boolean isCoffeeTime,
                              final Boolean isActive,
@@ -36,7 +36,7 @@ public class MyMeetingResponse {
     }
 
     public static MyMeetingResponse of(final Meeting meeting,
-                                       final int tardyCount,
+                                       final Integer tardyCount,
                                        final boolean isLoginUserMaster,
                                        final boolean isCoffeeTime,
                                        final boolean isActive,

--- a/backend/src/main/java/com/woowacourse/moragora/dto/response/meeting/MyMeetingResponse.java
+++ b/backend/src/main/java/com/woowacourse/moragora/dto/response/meeting/MyMeetingResponse.java
@@ -36,50 +36,6 @@ public class MyMeetingResponse {
     }
 
     public static MyMeetingResponse of(final Meeting meeting,
-                                       final Integer tardyCount,
-                                       final boolean isLoginUserMaster,
-                                       final boolean isCoffeeTime,
-                                       final boolean isActive,
-                                       final EventResponse upcomingEvent) {
-
-        return new MyMeetingResponse(
-                meeting.getId(),
-                meeting.getName(),
-                tardyCount,
-                isLoginUserMaster,
-                isCoffeeTime,
-                isActive,
-                upcomingEvent
-        );
-    }
-
-/*
-    public static MyMeetingResponse of(final Meeting meeting,
-                                       final Long userId
-                                       final boolean isActive,
-                                       final EventResponse upcomingEvent) {
-        return new MyMeetingResponse(
-                meeting.getId(),
-                meeting.getName(),
-                meeting.getTardyCount(),
-                meeting.isMaster(userId),
-                isActive,
-                upcomingEvent
-        );
-    }
-*/
-
-    /**
-     final Long id,
-     final String name,
-     final Integer tardyCount,
-     final Boolean isLoginUserMaster,
-     final Boolean isCoffeeTime,
-     final Boolean isActive,
-     final EventResponse upcomingEvent
-     */
-
-    public static MyMeetingResponse of(final Meeting meeting,
                                        final Long userId,
                                        final boolean isActive,
                                        final EventResponse upcomingEvent) {

--- a/backend/src/test/java/com/woowacourse/moragora/application/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/application/MeetingServiceTest.java
@@ -444,6 +444,39 @@ class MeetingServiceTest {
                 .isEqualTo(new MyMeetingsResponse(List.of(response1, response2)));
     }
 
+    @DisplayName("유저 id로 유저가 속한 모든 모임을 조회한다. (다가오는 일정이 없는 경우)")
+    @Test
+    void findAllByUserId_ifNoUpcomingEvent() {
+        // given
+        final Meeting meeting1 = MORAGORA.create();
+        final User user = KUN.create();
+        dataSupport.saveParticipant(user, meeting1, true);
+        final Event event1 = dataSupport.saveEvent(EVENT1.create(meeting1));
+        final Event event2 = dataSupport.saveEvent(EVENT1.create(meeting1));
+
+        final LocalTime entranceTime = event1.getStartTime();
+
+        final MyMeetingResponse response1 = MyMeetingResponse.builder()
+                .id(meeting1.getId())
+                .name(meeting1.getName())
+                .tardyCount(0)
+                .isLoginUserMaster(true)
+                .isCoffeeTime(false)
+                .isActive(false)
+                .upcomingEvent(null)
+                .build();
+
+        final LocalDateTime dateTime = LocalDateTime.of(2022, 8, 2, 10, 5);
+        serverTimeManager.refresh(dateTime);
+
+        // when
+        final MyMeetingsResponse response = meetingService.findAllByUserId(user.getId());
+
+        // then
+        assertThat(response).usingRecursiveComparison()
+                .isEqualTo(new MyMeetingsResponse(List.of(response1)));
+    }
+
     @DisplayName("미팅의 마스터를 다른 참가자로 수정한다.")
     @Test
     void updateMaster() {

--- a/backend/src/test/java/com/woowacourse/moragora/application/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/application/MeetingServiceTest.java
@@ -454,8 +454,6 @@ class MeetingServiceTest {
         final Event event1 = dataSupport.saveEvent(EVENT1.create(meeting1));
         final Event event2 = dataSupport.saveEvent(EVENT1.create(meeting1));
 
-        final LocalTime entranceTime = event1.getStartTime();
-
         final MyMeetingResponse response1 = MyMeetingResponse.builder()
                 .id(meeting1.getId())
                 .name(meeting1.getName())

--- a/backend/src/test/java/com/woowacourse/moragora/domain/event/EventTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/domain/event/EventTest.java
@@ -3,21 +3,14 @@ package com.woowacourse.moragora.domain.event;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 
 import com.woowacourse.moragora.application.ServerTimeManager;
 import com.woowacourse.moragora.domain.meeting.Meeting;
-import com.woowacourse.moragora.dto.request.meeting.MeetingRequest;
 import com.woowacourse.moragora.exception.meeting.IllegalEntranceLeaveTimeException;
-import com.woowacourse.moragora.exception.participant.InvalidParticipantException;
 import com.woowacourse.moragora.support.FakeDateTime;
 import com.woowacourse.moragora.support.fixture.EventFixtures;
 import com.woowacourse.moragora.support.fixture.MeetingFixtures;
 import com.woowacourse.moragora.support.timestrategy.DateTime;
-import com.woowacourse.moragora.support.timestrategy.ServerDateTime;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -122,5 +115,37 @@ class EventTest {
 
         // then
         assertThat(isActive).isTrue();
+    }
+
+    @DisplayName("출석부 열림 시간을 검증한다.")
+    @Test
+    void getOpenTime() {
+        // given
+        final Meeting meeting = MeetingFixtures.MORAGORA.create();
+        final Event event = EventFixtures.EVENT1.create(meeting);
+        final LocalDateTime virtualDateTime = LocalDateTime.of(2022, 8, 1, 10, 00);
+        serverTimeManager.refresh(virtualDateTime);
+
+        // when
+        final LocalTime openTime = event.getOpenTime(serverTimeManager);
+
+        // then
+        assertThat(openTime).isEqualTo(LocalTime.of(9, 30));
+    }
+
+    @DisplayName("출석부 닫힘 시간을 조회한다.")
+    @Test
+    void getCloseTime() {
+        // given
+        final Meeting meeting = MeetingFixtures.MORAGORA.create();
+        final Event event = EventFixtures.EVENT1.create(meeting);
+        final LocalDateTime virtualDateTime = LocalDateTime.of(2022, 8, 1, 10, 00);
+        serverTimeManager.refresh(virtualDateTime);
+
+        // when
+        final LocalTime closeTime = event.getCloseTime(serverTimeManager);
+
+        // then
+        assertThat(closeTime).isEqualTo(LocalTime.of(10, 05));
     }
 }

--- a/backend/src/test/java/com/woowacourse/moragora/domain/meeting/MeetingTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/domain/meeting/MeetingTest.java
@@ -91,8 +91,8 @@ class MeetingTest {
             }
 
             @Override
-            public Long getTardyCount() {
-                return 5L;
+            public Integer getTardyCount() {
+                return 5;
             }
         };
 
@@ -114,8 +114,8 @@ class MeetingTest {
         final Participant participant2 = new Participant(user2, meeting, false);
         participant1.mapMeeting(meeting);
         participant2.mapMeeting(meeting);
-        participant1.allocateTardyCount(1L);
-        participant2.allocateTardyCount(1L);
+        participant1.allocateTardyCount(1);
+        participant2.allocateTardyCount(1);
 
         // when
         final Boolean isTardyStackFull = meeting.isTardyStackFull();
@@ -135,8 +135,8 @@ class MeetingTest {
         final Participant participant2 = new Participant(user2, meeting, false);
         participant1.mapMeeting(meeting);
         participant2.mapMeeting(meeting);
-        participant1.allocateTardyCount(1L);
-        participant2.allocateTardyCount(0L);
+        participant1.allocateTardyCount(1);
+        participant2.allocateTardyCount(0);
 
         // when
         final Boolean isTardyStackFull = meeting.isTardyStackFull();
@@ -156,8 +156,8 @@ class MeetingTest {
         final Participant participant2 = new Participant(user2, meeting, false);
         participant1.mapMeeting(meeting);
         participant2.mapMeeting(meeting);
-        participant1.allocateTardyCount(5L);
-        participant2.allocateTardyCount(3L);
+        participant1.allocateTardyCount(5);
+        participant2.allocateTardyCount(3);
 
         // when
         final long totalTardyCount = meeting.calculateTardy();

--- a/backend/src/test/java/com/woowacourse/moragora/domain/meeting/MeetingTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/domain/meeting/MeetingTest.java
@@ -97,7 +97,7 @@ class MeetingTest {
         };
 
         // when
-        meeting.allocateParticipantsTardyCount(List.of(participantAndCount));
+        meeting.allocateTardyCount(List.of(participantAndCount));
 
         // then
         assertThat(participant.getTardyCount()).isEqualTo(5);

--- a/backend/src/test/java/com/woowacourse/moragora/domain/participant/ParticipantTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/domain/participant/ParticipantTest.java
@@ -87,7 +87,7 @@ class ParticipantTest {
         final Participant participant = new Participant(user, meeting, true);
 
         // when
-        participant.allocateTardyCount(5L);
+        participant.allocateTardyCount(5);
 
         // then
         assertThat(participant.getTardyCount()).isEqualTo(5);
@@ -106,10 +106,10 @@ class ParticipantTest {
                 .provider(GOOGLE)
                 .build();
         final Participant participant = new Participant(user, meeting, true);
-        participant.allocateTardyCount(5L);
+        participant.allocateTardyCount(5);
 
         // when
-        final Long tardyCount = participant.getTardyCount();
+        final Integer tardyCount = participant.getTardyCount();
 
         // then
         assertThat(tardyCount).isEqualTo(5);

--- a/backend/src/test/java/com/woowacourse/moragora/domain/query/QueryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/domain/query/QueryRepositoryTest.java
@@ -51,7 +51,7 @@ class QueryRepositoryTest {
 
         // when
         final List<ParticipantAndCount> participantAndCounts = queryRepository
-                .countParticipantsTardy(List.of(participant1, participant2, participant3), LocalDate.now());
+                .countParticipantsTardy(List.of(participant1, participant2, participant3));
 
         // then
         final long expected = participantAndCounts.stream()

--- a/backend/src/test/java/com/woowacourse/moragora/domain/query/QueryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/domain/query/QueryRepositoryTest.java
@@ -13,7 +13,6 @@ import com.woowacourse.moragora.support.DataSupport;
 import com.woowacourse.moragora.support.fixture.EventFixtures;
 import com.woowacourse.moragora.support.fixture.MeetingFixtures;
 import com.woowacourse.moragora.support.fixture.UserFixtures;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
@@ -51,7 +50,7 @@ class QueryRepositoryTest {
 
         // when
         final List<ParticipantAndCount> participantAndCounts = queryRepository
-                .countParticipantsTardy(List.of(participant1, participant2, participant3));
+                .countParticipantsTardyDto(List.of(participant1, participant2, participant3));
 
         // then
         final long expected = participantAndCounts.stream()


### PR DESCRIPTION
close #507 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/meeting-find-all-by-me -> dev

## 요구사항
- 나의 미팅 조회 `/meetings/me` 에 대해
  - 리펙터링
  - 쿼리 최적화


## 변경사항

`MeetingAcceptanceTest.findMy` 에 대해 응답시간, 쿼리 수 비교

- 리펙터링 전
![image](https://user-images.githubusercontent.com/66164361/195487818-c1baaac4-675d-4116-87c9-85cda90c1b8e.png)

- 리펙터링 후
![image](https://user-images.githubusercontent.com/66164361/195487663-63e39eb0-e1e6-4fb2-98f4-b5c3e98c1a65.png)

### 쿼리 5번이 나가는 이유

![image](https://user-images.githubusercontent.com/66164361/195494658-8abd1dde-bea2-46b2-a747-16bc2031859d.png)


- Meeting + Participant 조회 (fetch join) `1`번
  - 각 조회 결과(Meeting)에 대해
    - Participant와 지각횟수 조회 `1`번
    - 다가오는 이벤트 조회 `1`번

- 5번: 1 + 2 * (1+ 1)

### Event Join 제거

```sql
select count(a) "
        +   "from Attendance a "
        + "  inner join a.event e "
        +   "where a.participant.id = p.id and a.status = 'TARDY' and a.disabled = false and e.date <= :date
```

- Event 있는 경우
```java
@Query("select p as participant, "
        +   "(select count(a) "
        +   "from Attendance a "
        + "  inner join a.event e "
        +   "where a.participant.id = p.id and a.status = 'TARDY' and a.disabled = false and e.date <= :date) "
        +   "as tardyCount "
        + "from Participant p join fetch p.user "
        + "where p in :participants")
List<ParticipantAndCount> countParticipantsTardy(@Param("participants") final List<Participant> participants,
                                                    @Param("date") final LocalDate date);
```

- Event가 없는 경우
```java
@Query("select p as participant, "
        +   "(select count(a) "
        +   "from Attendance a "
        +   "where a.participant.id = p.id and a.status = 'TARDY' and a.disabled = false) "
        +   "as tardyCount "
        + "from Participant p join fetch p.user "
        + "where p in :participants")
List<ParticipantAndCount> countParticipantsTardy_2(@Param("participants") final List<Participant> participants);
```

## 리펙터링 전

> 호출 순서
- findAllByUserId
  - generateMyMeetingResponse
    - getMeetingAttendances
    - countTardyByParticipant
  - EventResponse.of


```java
private MyMeetingResponse generateMyMeetingResponse(final Participant participant, final LocalDate today) {
    final Meeting meeting = participant.getMeeting();
    final boolean isLoginUserMaster = participant.getIsMaster();

    final MeetingAttendances meetingAttendances = getMeetingAttendances(meeting, today);
    final boolean isCoffeeTime = meetingAttendances.isTardyStackFull();
    final int tardyCount = countTardyByParticipant(participant, meetingAttendances);

    final Optional<Event> upcomingEvent = eventRepository
            .findFirstByMeetingIdAndDateGreaterThanEqualOrderByDate(meeting.getId(), today);
    if (upcomingEvent.isEmpty()) {
        return MyMeetingResponse.of(
                meeting, tardyCount, isLoginUserMaster, isCoffeeTime, false, null
        );
    }
    final Event event = upcomingEvent.get();
    final LocalTime startTime = event.getStartTime();
    final boolean isActive = event.isSameDate(today) && serverTimeManager.isAttendanceOpen(startTime);
    final LocalTime attendanceOpenTime = serverTimeManager.calculateOpenTime(startTime);
    final LocalTime attendanceClosedTime = serverTimeManager.calculateAttendanceCloseTime(startTime);
    return MyMeetingResponse.of(meeting, tardyCount, isLoginUserMaster, isCoffeeTime, isActive, EventResponse.of(event, attendanceOpenTime, attendanceClosedTime));
}
```

```java
private MeetingAttendances getMeetingAttendances(final Meeting meeting, final LocalDate today) {
    final List<Long> participantIds = meeting.getParticipantIds();
    final List<Attendance> foundAttendances = attendanceRepository
            .findByParticipantIdInAndEventDateLessThanEqual(participantIds, today);
    return new MeetingAttendances(foundAttendances, participantIds.size());
}
```

```java
private int countTardyByParticipant(final Participant participant, final MeetingAttendances meetingAttendances) {
    final ParticipantAttendances participantAttendances = meetingAttendances
            .extractAttendancesByParticipant(participant);
    return participantAttendances.countTardy();
}
```

```java
public static EventResponse of(final Event event,
                                final LocalTime attendanceOpenTime,
                                final LocalTime attendanceClosedTime) {
    return new EventResponse(
            event.getId(),
            attendanceOpenTime.format(TIME_FORMATTER),
            attendanceClosedTime.format(TIME_FORMATTER),
            event.getStartTime().format(TIME_FORMATTER),
            event.getEndTime().format(TIME_FORMATTER),
            event.getDate()
    );
}
```

## 리펙터링 후

> 호출 순서
- findAllByUserId 
  - getMyMeetingsResponse
    - getMyMeetingResponse


```java
private List<MyMeetingResponse> getMyMeetingsResponse(final Long userId,
                                                        final List<Meeting> meetings,
                                                        final LocalDate today) {
    final List<MyMeetingResponse> myMeetingResponses = new ArrayList<>();
    for (final Meeting meeting : meetings) {
        final List<ParticipantAndCount> participantAndCounts =
                queryRepository.countParticipantsTardy(meeting.getParticipants());
        meeting.allocateParticipantsTardyCount(participantAndCounts);
        meeting.isTardyStackFull();
        meeting.isMaster(userId);
        final Event upcomingEvent = eventRepository
                .findFirstByMeetingIdAndDateGreaterThanEqualOrderByDate(meeting.getId(), today)
                .orElse(null);
        MyMeetingResponse myMeetingResponse = getMyMeetingResponse(userId, today, meeting, upcomingEvent);
        myMeetingResponses.add(myMeetingResponse);
    }
    return myMeetingResponses;
}
```

```java
private MyMeetingResponse getMyMeetingResponse(final Long userId,
                                                final LocalDate today,
                                                final Meeting meeting,
                                                final Event upcomingEvent) {
boolean isActive = false;
EventResponse eventResponse = null;
if (upcomingEvent != null) {
        isActive = upcomingEvent.isActive(today, serverTimeManager);
        final LocalTime attendanceOpenTime = upcomingEvent.getOpenTime(serverTimeManager);
        final LocalTime attendanceClosedTime = upcomingEvent.getCloseTime(serverTimeManager);
        eventResponse = EventResponse.of(upcomingEvent, attendanceOpenTime, attendanceClosedTime);
}
return MyMeetingResponse.of(meeting, userId, isActive, eventResponse);
}
```

## 수정 예정사항
- MyMeetingResponse 명세에 있는 tardyCount는 방 전체의 지각수가 아닌 `나의 지각 횟수` 인데 현재는 방 전체에 대한 지각횟수로 되어 있습니다  !  변경 예정에 있어요 !!
- Assignee가 할 것 :: `미팅에 대한 지각 총 횟수` (미팅에 대한 coffeeTime) 와 `나의 지각 총 횟수` 
- get -> create
- createDtos 에서 domain과 dto 생성 책임 분리 후
  - meetings에서 dto생성 !