### PR TITLE
[FE] Mobile 상단, 하단 navigation Layout 버그 수정

### DIFF
--- a/frontend/emotion.d.ts
+++ b/frontend/emotion.d.ts
@@ -19,9 +19,18 @@ type Colors =
   | 'tint'
   | 'transparent';
 
+type ZIndex =
+  | 'surface'
+  | 'slightly-float'
+  | 'footer'
+  | 'header'
+  | 'modal'
+  | 'modal-background';
+
 declare module '@emotion/react' {
   export interface Theme {
     colors: Record<Colors, string>;
     media: MediaQuery<ScreenSize>;
+    zIndex: Record<ZIndex, number>;
   }
 }

--- a/frontend/src/App.styled.ts
+++ b/frontend/src/App.styled.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 export const SpinnerBox = styled.div`
-  flex: 1;
+  height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,9 +51,11 @@ const App = () => {
   if (isLoading) {
     return (
       <AppLayout>
-        <S.SpinnerBox>
-          <Spinner />
-        </S.SpinnerBox>
+        <Body>
+          <S.SpinnerBox>
+            <Spinner />
+          </S.SpinnerBox>
+        </Body>
       </AppLayout>
     );
   }

--- a/frontend/src/components/@shared/Calendar/DateCell/DateCell.styled.ts
+++ b/frontend/src/components/@shared/Calendar/DateCell/DateCell.styled.ts
@@ -56,7 +56,7 @@ export const Layout = styled.div<{
       border-radius: 0.1rem;
       font-size: 0.75rem;
       color: white;
-      z-index: 10;
+      z-index: ${({ theme: { zIndex } }) => zIndex['slightly-float']};
     }
   }
 `;

--- a/frontend/src/components/@shared/ModalWindow/ModalWindow.styled.ts
+++ b/frontend/src/components/@shared/ModalWindow/ModalWindow.styled.ts
@@ -9,7 +9,7 @@ export const Layout = styled.div`
   border: 2px solid ${({ theme: { colors } }) => colors['primary']};
   border-radius: 0.5rem;
   background-color: ${({ theme: { colors } }) => colors['white']};
-  z-index: 50;
+  z-index: ${({ theme: { zIndex } }) => zIndex['modal']}; ;
 `;
 
 export const Title = styled.h2`

--- a/frontend/src/components/CoffeeStackModal/CoffeeStackModal.styled.ts
+++ b/frontend/src/components/CoffeeStackModal/CoffeeStackModal.styled.ts
@@ -10,7 +10,7 @@ export const Layout = styled.div`
   border: 2px solid ${({ theme: { colors } }) => colors['primary']};
   border-radius: 0.5rem;
   background-color: ${({ theme: { colors } }) => colors['white']};
-  z-index: 50;
+  z-index: ${({ theme: { zIndex } }) => zIndex['modal']};
 `;
 
 export const StatsBox = styled.div`

--- a/frontend/src/components/MemberAddInput/MemberAddInput.styled.ts
+++ b/frontend/src/components/MemberAddInput/MemberAddInput.styled.ts
@@ -10,7 +10,7 @@ export const QueryResultList = styled.ul`
   position: absolute;
   width: 100%;
   max-height: 12rem;
-  z-index: 10;
+  z-index: ${({ theme: { zIndex } }) => zIndex['slightly-float']};
 
   display: flex;
   flex-direction: column;
@@ -62,7 +62,7 @@ export const AddedMembersListItem = styled.li<{ caption: string }>`
       border-radius: 0.1rem;
       font-size: 0.75rem;
       color: white;
-      z-index: 10;
+      z-index: ${({ theme: { zIndex } }) => zIndex['slightly-float']};
     }
   }
 `;

--- a/frontend/src/components/ModalPortal/ModalPortal.styled.ts
+++ b/frontend/src/components/ModalPortal/ModalPortal.styled.ts
@@ -7,7 +7,7 @@ export const Layout = styled.div`
   justify-content: center;
   align-items: center;
   background-color: rgba(0, 0, 0, 0.4);
-  z-index: 49;
+  z-index: ${({ theme: { zIndex } }) => zIndex['modal-background']};
 `;
 
 export const ModalBackgroundBox = styled.div`

--- a/frontend/src/components/layouts/AppLayout/AppLayout.styled.ts
+++ b/frontend/src/components/layouts/AppLayout/AppLayout.styled.ts
@@ -2,6 +2,6 @@ import styled from '@emotion/styled';
 
 export const AppLayout = styled.div`
   position: relative;
-  padding: 4rem 0;
+  padding: 5rem 0;
   background-color: ${({ theme: { colors } }) => colors['surface']};
 `;

--- a/frontend/src/components/layouts/AppLayout/AppLayout.styled.ts
+++ b/frontend/src/components/layouts/AppLayout/AppLayout.styled.ts
@@ -1,7 +1,10 @@
 import styled from '@emotion/styled';
 
+const appHeight = window.innerHeight / 16;
+
 export const AppLayout = styled.div`
   position: relative;
-  padding: 5rem 0;
+  height: ${appHeight - 9}rem;
+  padding: 5rem 0 4rem;
   background-color: ${({ theme: { colors } }) => colors['surface']};
 `;

--- a/frontend/src/components/layouts/AppLayout/AppLayout.styled.ts
+++ b/frontend/src/components/layouts/AppLayout/AppLayout.styled.ts
@@ -1,10 +1,8 @@
 import styled from '@emotion/styled';
 
-const appHeight = window.innerHeight / 16;
-
-export const AppLayout = styled.div`
+export const AppLayout = styled.div<{ appHeight: number }>`
   position: relative;
-  height: ${appHeight - 9}rem;
+  height: ${({ appHeight }) => appHeight / 16 - 9}rem;
   padding: 5rem 0 4rem;
   background-color: ${({ theme: { colors } }) => colors['surface']};
 `;

--- a/frontend/src/components/layouts/AppLayout/AppLayout.styled.ts
+++ b/frontend/src/components/layouts/AppLayout/AppLayout.styled.ts
@@ -2,7 +2,5 @@ import styled from '@emotion/styled';
 
 export const AppLayout = styled.div<{ appHeight: number }>`
   position: relative;
-  height: ${({ appHeight }) => appHeight / 16 - 9}rem;
   padding: 5rem 0 4rem;
-  background-color: ${({ theme: { colors } }) => colors['surface']};
 `;

--- a/frontend/src/components/layouts/AppLayout/index.tsx
+++ b/frontend/src/components/layouts/AppLayout/index.tsx
@@ -1,5 +1,20 @@
+import React, { useEffect, useState } from 'react';
+import { debounce } from 'utils/debounce';
 import * as S from './AppLayout.styled';
 
-const AppLayout = S.AppLayout;
+const AppLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [appHeight, setAppHeight] = useState(window.innerHeight);
+
+  useEffect(() => {
+    window.addEventListener(
+      'resize',
+      debounce(() => {
+        setAppHeight(window.innerHeight);
+      }, 100)
+    );
+  }, []);
+
+  return <S.AppLayout appHeight={appHeight}>{children}</S.AppLayout>;
+};
 
 export default AppLayout;

--- a/frontend/src/components/layouts/Body/Body.styled.ts
+++ b/frontend/src/components/layouts/Body/Body.styled.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
 
 export const Body = styled.main`
-  height: calc(100vh - 10rem);
+  height: 100%;
 `;

--- a/frontend/src/components/layouts/Body/Body.styled.ts
+++ b/frontend/src/components/layouts/Body/Body.styled.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
 
 export const Body = styled.main`
-  height: calc(100vh - 8rem);
+  height: calc(100vh - 10rem);
 `;

--- a/frontend/src/components/layouts/Footer/Footer.styled.ts
+++ b/frontend/src/components/layouts/Footer/Footer.styled.ts
@@ -3,7 +3,10 @@ import { NavLink } from 'react-router-dom';
 
 export const Nav = styled.nav`
   position: fixed;
-  inset: calc(100vh - 4rem) 0 0 0;
+  height: 4rem;
+  right: 0;
+  bottom: 0;
+  left: 0;
   display: flex;
   justify-content: space-evenly;
   align-items: center;

--- a/frontend/src/components/layouts/Footer/Footer.styled.ts
+++ b/frontend/src/components/layouts/Footer/Footer.styled.ts
@@ -13,6 +13,7 @@ export const Nav = styled.nav`
   border-top: 1px solid ${({ theme: { colors } }) => colors['background']};
   padding: 0 1rem;
   background-color: ${({ theme: { colors } }) => colors['white']};
+  z-index: ${({ theme: { zIndex } }) => zIndex['footer']};
 `;
 
 export const MenuNavLink = styled(NavLink)`

--- a/frontend/src/components/layouts/Header/Header.styled.ts
+++ b/frontend/src/components/layouts/Header/Header.styled.ts
@@ -11,6 +11,7 @@ export const Layout = styled.header`
   justify-content: space-between;
   align-items: center;
   background-color: ${({ theme: { colors } }) => colors['surface']};
+  z-index: ${({ theme: { zIndex } }) => zIndex['header']};
 `;
 
 export const Box = styled.div`

--- a/frontend/src/components/layouts/Header/Header.styled.ts
+++ b/frontend/src/components/layouts/Header/Header.styled.ts
@@ -2,7 +2,10 @@ import styled from '@emotion/styled';
 
 export const Layout = styled.header`
   position: fixed;
-  inset: 0 0 calc(100vh - 4rem) 0;
+  height: 4rem;
+  top: 0;
+  right: 0;
+  left: 0;
   padding: 0.5rem;
   display: flex;
   justify-content: space-between;

--- a/frontend/src/pages/CoffeeStackPage/CoffeeStackPage.styled.ts
+++ b/frontend/src/pages/CoffeeStackPage/CoffeeStackPage.styled.ts
@@ -7,7 +7,6 @@ export const Layout = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1;
-  overflow: hidden;
 `;
 
 export const SpinnerBox = styled.div`
@@ -93,7 +92,6 @@ export const UserListSection = styled.section`
 
 export const UserListBox = styled.div`
   display: flex;
-  overflow-y: hidden;
 `;
 
 export const UserList = styled.ul`
@@ -105,8 +103,6 @@ export const UserList = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  overflow-x: hidden;
-  overflow-y: scroll;
 `;
 
 export const Paragraph = styled.p``;

--- a/frontend/src/pages/MeetingConfigPage/MasterAssignSection/MasterAssignSection.styled.ts
+++ b/frontend/src/pages/MeetingConfigPage/MasterAssignSection/MasterAssignSection.styled.ts
@@ -34,7 +34,7 @@ export const ParticipantList = styled.ul`
   position: absolute;
   width: 100%;
   max-height: 12rem;
-  z-index: 10;
+  z-index: ${({ theme: { zIndex } }) => zIndex['slightly-float']};
 
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/MeetingDetailPage/MeetingDetailPage.styled.ts
+++ b/frontend/src/pages/MeetingDetailPage/MeetingDetailPage.styled.ts
@@ -33,7 +33,7 @@ export const TabNavBox = styled.div`
   height: 3rem;
   background-color: ${({ theme: { colors } }) => colors['surface']};
   box-shadow: 0 0.1rem 0.1rem ${({ theme: { colors } }) => colors['background']};
-  z-index: 10;
+  z-index: ${({ theme: { zIndex } }) => zIndex['slightly-float']};
 `;
 
 export const TabNav = styled.nav`
@@ -46,7 +46,7 @@ export const TabNav = styled.nav`
 export const TabNavLink = styled(NavLink)`
   text-decoration: none;
   color: ${({ theme: { colors } }) => colors['subtle-light']};
-  z-index: 1;
+  z-index: ${({ theme: { zIndex } }) => zIndex['slightly-float']};
 
   transition: all 300ms ease-out;
 

--- a/frontend/src/pages/MeetingListPage/MeetingListPage.styled.ts
+++ b/frontend/src/pages/MeetingListPage/MeetingListPage.styled.ts
@@ -5,7 +5,6 @@ export const Layout = styled.div`
   height: 100%;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
 `;
 
 export const SpinnerBox = styled.div`
@@ -82,7 +81,6 @@ export const MeetingList = styled.ul`
 export const CoffeeStackSection = styled.section`
   display: flex;
   flex-direction: column;
-  overflow: hidden;
 `;
 
 export const CoffeeStackList = styled.ul`
@@ -94,8 +92,6 @@ export const CoffeeStackList = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  overflow-x: hidden;
-  overflow-y: scroll;
 `;
 
 export const EmptyStateBox = styled.div`

--- a/frontend/src/styles/GlobalStyles/index.tsx
+++ b/frontend/src/styles/GlobalStyles/index.tsx
@@ -14,6 +14,7 @@ const GlobalStyles = () => (
       styles={css`
         body {
           color: #19191b;
+          background-color: #fafafa;
         }
 
         .noselect {

--- a/frontend/src/styles/themes/theme.ts
+++ b/frontend/src/styles/themes/theme.ts
@@ -22,6 +22,15 @@ const SCREEN_SIZES = {
   xl: 1680,
 };
 
+const zIndex = {
+  modal: 100,
+  'modal-background': 90,
+  footer: 50,
+  header: 50,
+  'slightly-float': 10,
+  surface: 0,
+};
+
 const media: Theme['media'] = {
   xs: (...args) => css`
     @media only screen and (max-width: ${SCREEN_SIZES.xs}px) {
@@ -56,4 +65,5 @@ const media: Theme['media'] = {
 export const theme: Theme = {
   colors,
   media,
+  zIndex,
 };

--- a/frontend/src/utils/debounce.ts
+++ b/frontend/src/utils/debounce.ts
@@ -1,0 +1,14 @@
+export function debounce<T extends (...args: any[]) => unknown>(
+  callback: T,
+  delay: number
+) {
+  let timer: NodeJS.Timeout;
+
+  return function (...args: Parameters<T>) {
+    clearTimeout(timer);
+
+    timer = setTimeout(() => {
+      callback(...args);
+    }, delay);
+  };
+}


### PR DESCRIPTION
Close #499 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
hotfix/1.1.4 -> main

## 요구사항
- 모바일 환경에서 상단, 하단 네비게이션 바가 정상적으로 나타난다.

## 변경사항
- `Header`, `Footer` layout 조정을 inset에서 height 지정으로 변경
- `AppLayout` Height 적용
  - 주소창을 제외한 레이아웃 뷰포트 높이를 나타내는 `window.innerHeight`를 사용해서 높이 지정
- `App` 로딩 스피너 `Box` 추가

## 수정 후 모바일 환경 레이아웃
<img width="250" src="https://user-images.githubusercontent.com/61308364/195780596-54b62cc1-e0c6-4c1b-821f-f970a0e6f394.png" />

