### PR TITLE
[FE] 회원가입 시 이메일 인증 기능 추가

### DIFF
--- a/frontend/cypress/e2e/app.cy.ts
+++ b/frontend/cypress/e2e/app.cy.ts
@@ -10,14 +10,14 @@ describe('유저', () => {
       password: 'newuserpw1!',
       passwordConfirm: 'newuserpw1!',
       nickname: '신규회원',
-      code: '123456',
     };
+    const code = '123456';
 
     it('성공 시 참여 중인 모임 목록 페이지로 이동한다.', () => {
       cy.get('a[class*="-RegisterLink"]').should('exist').click();
       cy.get('input[name="email"]').type(newUser.email);
       cy.get('button[class*="-EmailCheckButton"]').click();
-      cy.get('input[name="code"]').type(newUser.code);
+      cy.get('input[name="code"]').type(code);
       cy.get('button[class*="-ConfirmButton"]').click();
       cy.get('input[name="password"]').type(newUser.password);
       cy.get('input[name="passwordConfirm"]').type(newUser.passwordConfirm);
@@ -83,18 +83,18 @@ describe('모임', () => {
       password: 'newuserpw1!',
       passwordConfirm: 'newuserpw1!',
       nickname: '신규회원',
-      code: '123456',
     };
     const newMeeting = {
       name: '새로운 모임',
       member: ['user1', 'user2'],
     };
+    const code = '123456';
 
     it('성공 시 생성된 모임 페이지로 이동한다.', () => {
       cy.get('a[class*="-RegisterLink"]').should('exist').click();
       cy.get('input[name="email"]').type(newUser.email);
       cy.get('button[class*="-EmailCheckButton"]').click();
-      cy.get('input[name="code"]').type(newUser.code);
+      cy.get('input[name="code"]').type(code);
       cy.get('button[class*="-ConfirmButton"]').click();
       cy.get('input[name="password"]').type(newUser.password);
       cy.get('input[name="passwordConfirm"]').type(newUser.passwordConfirm);

--- a/frontend/cypress/e2e/app.cy.ts
+++ b/frontend/cypress/e2e/app.cy.ts
@@ -10,12 +10,15 @@ describe('유저', () => {
       password: 'newuserpw1!',
       passwordConfirm: 'newuserpw1!',
       nickname: '신규회원',
+      code: '123456',
     };
 
     it('성공 시 참여 중인 모임 목록 페이지로 이동한다.', () => {
       cy.get('a[class*="-RegisterLink"]').should('exist').click();
       cy.get('input[name="email"]').type(newUser.email);
       cy.get('button[class*="-EmailCheckButton"]').click();
+      cy.get('input[name="code"]').type(newUser.code);
+      cy.get('button[class*="-ConfirmButton"]').click();
       cy.get('input[name="password"]').type(newUser.password);
       cy.get('input[name="passwordConfirm"]').type(newUser.passwordConfirm);
       cy.get('input[name="nickname"]').type(newUser.nickname).type('{enter}');

--- a/frontend/cypress/e2e/app.cy.ts
+++ b/frontend/cypress/e2e/app.cy.ts
@@ -83,6 +83,7 @@ describe('모임', () => {
       password: 'newuserpw1!',
       passwordConfirm: 'newuserpw1!',
       nickname: '신규회원',
+      code: '123456',
     };
     const newMeeting = {
       name: '새로운 모임',
@@ -93,6 +94,8 @@ describe('모임', () => {
       cy.get('a[class*="-RegisterLink"]').should('exist').click();
       cy.get('input[name="email"]').type(newUser.email);
       cy.get('button[class*="-EmailCheckButton"]').click();
+      cy.get('input[name="code"]').type(newUser.code);
+      cy.get('button[class*="-ConfirmButton"]').click();
       cy.get('input[name="password"]').type(newUser.password);
       cy.get('input[name="passwordConfirm"]').type(newUser.passwordConfirm);
       cy.get('input[name="nickname"]').type(newUser.nickname).type('{enter}');

--- a/frontend/src/apis/userApis.ts
+++ b/frontend/src/apis/userApis.ts
@@ -24,6 +24,7 @@ export const postEmailSendApi = (payload: UserEmailSendRequestBody) =>
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(payload),
+    credentials: 'include',
   });
 
 export const postVerifyCodeAPi = (payload: EmailCodeVerifyRequestBody) =>
@@ -33,6 +34,7 @@ export const postVerifyCodeAPi = (payload: EmailCodeVerifyRequestBody) =>
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(payload),
+    credentials: 'include',
   });
 
 export const submitRegisterApi = async (payload: UserRegisterRequestBody) => {
@@ -42,6 +44,7 @@ export const submitRegisterApi = async (payload: UserRegisterRequestBody) => {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(payload),
+    credentials: 'include',
   });
 
   const { nickname, ...loginRequestBody } = payload;

--- a/frontend/src/apis/userApis.ts
+++ b/frontend/src/apis/userApis.ts
@@ -8,6 +8,8 @@ import {
   UserUpdateNicknameRequestBody,
   UserUpdatePasswordRequestBody,
   GoogleLoginRequestBody,
+  UserEmailSendRequestBody,
+  EmailCodeVerifyRequestBody,
 } from 'types/userType';
 import {
   AttendancesResponseBody,
@@ -15,12 +17,22 @@ import {
 } from 'types/attendanceType';
 import request from '../utils/request';
 
-export const checkEmailApi = (email: User['email']) => () =>
-  request<{ isExist: boolean }>(`/users/check-email?email=${email}`, {
-    method: 'GET',
+export const postEmailSendApi = (payload: UserEmailSendRequestBody) =>
+  request<{ expiredTime: number }>(`/emails/send`, {
+    method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
+    body: JSON.stringify(payload),
+  });
+
+export const postVerifyCodeAPi = (payload: EmailCodeVerifyRequestBody) =>
+  request(`/emails/verify`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
   });
 
 export const submitRegisterApi = async (payload: UserRegisterRequestBody) => {

--- a/frontend/src/apis/userApis.ts
+++ b/frontend/src/apis/userApis.ts
@@ -18,7 +18,7 @@ import {
 import request from '../utils/request';
 
 export const postEmailSendApi = (payload: UserEmailSendRequestBody) =>
-  request<{ expiredTime: number }>(`/emails/send`, {
+  request<{ expiredTime: number }>(`/email/send`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -28,7 +28,7 @@ export const postEmailSendApi = (payload: UserEmailSendRequestBody) =>
   });
 
 export const postVerifyCodeAPi = (payload: EmailCodeVerifyRequestBody) =>
-  request(`/emails/verify`, {
+  request(`/email/verify`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/components/EmailConfirmModal/EmailConfirmModal.stories.jsx
+++ b/frontend/src/components/EmailConfirmModal/EmailConfirmModal.stories.jsx
@@ -1,0 +1,13 @@
+import EmailConfirmModal from '.';
+
+export default {
+  title: 'Components/EmailConfirmModal',
+  component: EmailConfirmModal,
+};
+
+const Template = (args) => {
+  return <EmailConfirmModal {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/frontend/src/components/EmailConfirmModal/EmailConfirmModal.stories.jsx
+++ b/frontend/src/components/EmailConfirmModal/EmailConfirmModal.stories.jsx
@@ -9,5 +9,14 @@ const Template = (args) => {
   return <EmailConfirmModal {...args} />;
 };
 
+const timer = new Date();
+timer.setMinutes(timer.getMinutes() + 5);
+
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  email: 'user1@google.com',
+  expiredTimestamp: timer.getTime(),
+  onSuccess: () => {},
+  onDismiss: () => {},
+  refetch: () => {},
+};

--- a/frontend/src/components/EmailConfirmModal/EmailConfirmModal.styled.ts
+++ b/frontend/src/components/EmailConfirmModal/EmailConfirmModal.styled.ts
@@ -61,7 +61,7 @@ export const ExpiredTimeParagraph = styled.p`
   color: gray;
 `;
 
-export const ResendButton = styled(_Button)`
+export const ReSendButton = styled(_Button)`
   padding: 0;
   height: 2rem;
   font-size: 0.75rem;

--- a/frontend/src/components/EmailConfirmModal/EmailConfirmModal.styled.ts
+++ b/frontend/src/components/EmailConfirmModal/EmailConfirmModal.styled.ts
@@ -3,6 +3,7 @@ import _Button from 'components/@shared/Button';
 import Input from 'components/@shared/Input';
 
 export const Layout = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   width: 18rem;
@@ -44,6 +45,12 @@ export const NumberInput = styled(Input)`
   :focus {
     outline: none;
   }
+
+  ::-webkit-outer-spin-button,
+  ::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
 `;
 
 export const ExpiredTimeParagraph = styled.p`
@@ -54,4 +61,10 @@ export const Button = styled(_Button)`
   padding: 0;
   height: 2rem;
   font-size: 0.75rem;
+`;
+
+export const CloseButton = styled.button`
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
 `;

--- a/frontend/src/components/EmailConfirmModal/EmailConfirmModal.styled.ts
+++ b/frontend/src/components/EmailConfirmModal/EmailConfirmModal.styled.ts
@@ -80,6 +80,8 @@ export const ConfirmButton = styled(_Button)`
 
 export const CloseButton = styled.button`
   position: absolute;
-  top: 1rem;
-  right: 1rem;
+  top: 0.5rem;
+  right: 0.5rem;
+  font-size: 1.5rem;
+  color: gray;
 `;

--- a/frontend/src/components/EmailConfirmModal/EmailConfirmModal.styled.ts
+++ b/frontend/src/components/EmailConfirmModal/EmailConfirmModal.styled.ts
@@ -46,6 +46,10 @@ export const NumberInput = styled(Input)`
     outline: none;
   }
 
+  :disabled {
+    background-color: transparent;
+  }
+
   ::-webkit-outer-spin-button,
   ::-webkit-inner-spin-button {
     -webkit-appearance: none;
@@ -57,7 +61,18 @@ export const ExpiredTimeParagraph = styled.p`
   color: gray;
 `;
 
-export const Button = styled(_Button)`
+export const ResendButton = styled(_Button)`
+  padding: 0;
+  height: 2rem;
+  font-size: 0.75rem;
+
+  background-color: ${({ theme: { colors } }) => colors['primary-subtle']};
+  &:hover {
+    background-color: ${({ theme: { colors } }) => colors['primary']};
+  }
+`;
+
+export const ConfirmButton = styled(_Button)`
   padding: 0;
   height: 2rem;
   font-size: 0.75rem;

--- a/frontend/src/components/EmailConfirmModal/EmailConfirmModal.styled.ts
+++ b/frontend/src/components/EmailConfirmModal/EmailConfirmModal.styled.ts
@@ -16,8 +16,6 @@ export const Layout = styled.div`
 `;
 
 export const Paragraph = styled.p`
-  display: flex;
-  flex-direction: column;
   font-weight: 700;
   font-size: 1.25rem;
 `;

--- a/frontend/src/components/EmailConfirmModal/EmailConfirmModal.styled.ts
+++ b/frontend/src/components/EmailConfirmModal/EmailConfirmModal.styled.ts
@@ -1,0 +1,57 @@
+import styled from '@emotion/styled';
+import _Button from 'components/@shared/Button';
+import Input from 'components/@shared/Input';
+
+export const Layout = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 18rem;
+  padding: 1.5rem;
+  gap: 1.5rem;
+  border: 2px solid ${({ theme: { colors } }) => colors['primary']};
+  border-radius: 0.5rem;
+  background-color: ${({ theme: { colors } }) => colors['white']};
+  z-index: 50;
+`;
+
+export const Paragraph = styled.p`
+  display: flex;
+  flex-direction: column;
+  font-weight: 700;
+  font-size: 1.25rem;
+`;
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+export const InputBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid lightgray;
+`;
+
+export const NumberInput = styled(Input)`
+  border: none;
+  font-size: 2rem;
+  padding: 0;
+  width: 100%;
+
+  :focus {
+    outline: none;
+  }
+`;
+
+export const ExpiredTimeParagraph = styled.p`
+  color: gray;
+`;
+
+export const Button = styled(_Button)`
+  padding: 0;
+  height: 2rem;
+  font-size: 0.75rem;
+`;

--- a/frontend/src/components/EmailConfirmModal/index.tsx
+++ b/frontend/src/components/EmailConfirmModal/index.tsx
@@ -1,0 +1,25 @@
+import * as S from './EmailConfirmModal.styled';
+
+type EmailConfirmModalProps = {};
+
+const EmailConfirmModal: React.FC<
+  React.PropsWithChildren<EmailConfirmModalProps>
+> = () => {
+  return (
+    <S.Layout>
+      <S.Paragraph>
+        <span>이메일로 전송된</span>
+        <span>인증번호 6자리를 입력해주세요</span>
+      </S.Paragraph>
+      <S.Form>
+        <S.InputBox>
+          <S.NumberInput placeholder="123456" />
+          <S.ExpiredTimeParagraph>04:12</S.ExpiredTimeParagraph>
+        </S.InputBox>
+        <S.Button>인증번호 재요청</S.Button>
+      </S.Form>
+    </S.Layout>
+  );
+};
+
+export default EmailConfirmModal;

--- a/frontend/src/components/EmailConfirmModal/index.tsx
+++ b/frontend/src/components/EmailConfirmModal/index.tsx
@@ -114,7 +114,7 @@ const EmailConfirmModal: React.FC<
           </S.ConfirmButton>
         )}
       </S.Form>
-      <S.CloseButton onClick={onDismiss}>Ⅹ</S.CloseButton>
+      <S.CloseButton onClick={onDismiss}>ⅹ</S.CloseButton>
     </S.Layout>
   );
 };

--- a/frontend/src/components/EmailConfirmModal/index.tsx
+++ b/frontend/src/components/EmailConfirmModal/index.tsx
@@ -97,10 +97,11 @@ const EmailConfirmModal: React.FC<
             placeholder={isTimeOver ? '인증시간 만료' : '123456'}
             disabled={isTimeOver}
             name="code"
-            required={true}
             onChange={handleInputChange}
             onKeyDown={handleInputKeyDown}
             value={code}
+            required
+            autoFocus
           />
           <S.ExpiredTimeParagraph>{remainTime}</S.ExpiredTimeParagraph>
         </S.InputBox>

--- a/frontend/src/components/EmailConfirmModal/index.tsx
+++ b/frontend/src/components/EmailConfirmModal/index.tsx
@@ -10,20 +10,14 @@ import { useEffect, useState } from 'react';
 type EmailConfirmModalProps = {
   email: User['email'];
   expiredTimestamp: number;
-  setIsEmailVerified: React.Dispatch<React.SetStateAction<boolean>>;
+  onSuccess: () => void;
   onDismiss: () => void;
-  refetchHandler: (variables: UserEmailSendRequestBody) => Promise<void>;
+  refetch: (variables: UserEmailSendRequestBody) => Promise<void>;
 };
 
 const EmailConfirmModal: React.FC<
   React.PropsWithChildren<EmailConfirmModalProps>
-> = ({
-  email,
-  expiredTimestamp,
-  setIsEmailVerified,
-  onDismiss,
-  refetchHandler,
-}) => {
+> = ({ email, expiredTimestamp, onSuccess, onDismiss, refetch: refetch }) => {
   const { values, errors, isSubmitting, onSubmit, register } = useForm();
   const [timeOver, setTimeOver] = useState(false);
   const { currentTimestamp } = useTimer(0);
@@ -32,8 +26,7 @@ const EmailConfirmModal: React.FC<
   const codeVerifyMutation = useMutation(postVerifyCodeAPi, {
     onSuccess: () => {
       alert('인증을 완료했습니다.');
-      setIsEmailVerified(true);
-      onDismiss();
+      onSuccess();
     },
     onError: () => {
       alert('인증을 실패했습니다.');
@@ -42,7 +35,7 @@ const EmailConfirmModal: React.FC<
 
   const handleReSendClick = () => {
     alert('인증 번호를 재요청했습니다.');
-    refetchHandler({ email });
+    refetch({ email });
   };
 
   const handleSubmit = () => {

--- a/frontend/src/components/EmailConfirmModal/index.tsx
+++ b/frontend/src/components/EmailConfirmModal/index.tsx
@@ -86,8 +86,9 @@ const EmailConfirmModal: React.FC<
   return (
     <S.Layout>
       <S.Paragraph>
-        <span>이메일로 전송된</span>
-        <span>인증번호 6자리를 입력해주세요.</span>
+        이메일로 전송된
+        <br />
+        인증번호 6자리를 입력해주세요.
       </S.Paragraph>
       <S.Form onSubmit={handleSubmit}>
         <S.InputBox>

--- a/frontend/src/components/EmailConfirmModal/index.tsx
+++ b/frontend/src/components/EmailConfirmModal/index.tsx
@@ -1,23 +1,96 @@
 import * as S from './EmailConfirmModal.styled';
+import { postVerifyCodeAPi } from 'apis/userApis';
+import useForm from 'hooks/useForm';
+import useMutation from 'hooks/useMutation';
+import useTimer from 'hooks/useTimer';
+import { User, UserEmailSendRequestBody } from 'types/userType';
+import { getTimestampDiff } from 'utils/timeUtil';
+import { useEffect, useState } from 'react';
 
-type EmailConfirmModalProps = {};
+type EmailConfirmModalProps = {
+  email: User['email'];
+  expiredTimestamp: number;
+  setIsEmailVerified: React.Dispatch<React.SetStateAction<boolean>>;
+  onDismiss: () => void;
+  refetchHandler: (variables: UserEmailSendRequestBody) => Promise<void>;
+};
 
 const EmailConfirmModal: React.FC<
   React.PropsWithChildren<EmailConfirmModalProps>
-> = () => {
+> = ({
+  email,
+  expiredTimestamp,
+  setIsEmailVerified,
+  onDismiss,
+  refetchHandler,
+}) => {
+  const { values, errors, isSubmitting, onSubmit, register } = useForm();
+  const [timeOver, setTimeOver] = useState(false);
+  const { currentTimestamp } = useTimer(0);
+  const remainTime = getTimestampDiff(expiredTimestamp, currentTimestamp);
+
+  const codeVerifyMutation = useMutation(postVerifyCodeAPi, {
+    onSuccess: () => {
+      alert('인증을 완료했습니다.');
+      setIsEmailVerified(true);
+      onDismiss();
+    },
+    onError: () => {
+      alert('인증을 실패했습니다.');
+    },
+  });
+
+  const handleReSendClick = () => {
+    alert('인증 번호를 재요청했습니다.');
+    refetchHandler({ email });
+  };
+
+  const handleSubmit = () => {
+    if (!errors['code'] && !timeOver) {
+      codeVerifyMutation.mutate({
+        email,
+        verifyCode: values['code'] as string,
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (expiredTimestamp - currentTimestamp <= 0) {
+      setTimeOver(true);
+    }
+  }, [expiredTimestamp, currentTimestamp]);
+
   return (
     <S.Layout>
       <S.Paragraph>
         <span>이메일로 전송된</span>
         <span>인증번호 6자리를 입력해주세요</span>
       </S.Paragraph>
-      <S.Form>
+      <S.Form {...onSubmit(handleSubmit)}>
         <S.InputBox>
-          <S.NumberInput placeholder="123456" />
-          <S.ExpiredTimeParagraph>04:12</S.ExpiredTimeParagraph>
+          <S.NumberInput
+            {...register('code', {
+              type: 'number',
+              placeholder: '123456',
+              required: true,
+              watch: true,
+              customValidations: [
+                {
+                  validate: (value) => /^[0-9]{6}$/.test(value),
+                  validationMessage: '입력값이 유효하지 않습니다.',
+                },
+              ],
+            })}
+          />
+          <S.ExpiredTimeParagraph>{remainTime}</S.ExpiredTimeParagraph>
         </S.InputBox>
-        <S.Button>인증번호 재요청</S.Button>
+        {errors['code'] || !values['code'] ? (
+          <S.Button onClick={handleReSendClick}>인증번호 재요청</S.Button>
+        ) : (
+          <S.Button disabled={isSubmitting || timeOver}>확인</S.Button>
+        )}
       </S.Form>
+      <S.CloseButton onClick={onDismiss}>Ⅹ</S.CloseButton>
     </S.Layout>
   );
 };

--- a/frontend/src/components/EmailConfirmModal/index.tsx
+++ b/frontend/src/components/EmailConfirmModal/index.tsx
@@ -16,7 +16,7 @@ type EmailConfirmModalProps = {
 
 const EmailConfirmModal: React.FC<
   React.PropsWithChildren<EmailConfirmModalProps>
-> = ({ email, expiredTimestamp, onSuccess, onDismiss, refetch: refetch }) => {
+> = ({ email, expiredTimestamp, onSuccess, onDismiss, refetch }) => {
   const [code, setCode] = useState('');
   const [isValidCode, setIsValidCode] = useState(false);
   const [isTimeOver, setIsTimeOver] = useState(false);
@@ -105,9 +105,9 @@ const EmailConfirmModal: React.FC<
           <S.ExpiredTimeParagraph>{remainTime}</S.ExpiredTimeParagraph>
         </S.InputBox>
         {!isValidCode || isTimeOver ? (
-          <S.ResendButton onClick={handleReSendClick}>
+          <S.ReSendButton onClick={handleReSendClick}>
             인증번호 재요청
-          </S.ResendButton>
+          </S.ReSendButton>
         ) : (
           <S.ConfirmButton disabled={codeVerifyMutation.isLoading}>
             확인

--- a/frontend/src/components/EmailConfirmModal/index.tsx
+++ b/frontend/src/components/EmailConfirmModal/index.tsx
@@ -19,7 +19,7 @@ const EmailConfirmModal: React.FC<
   React.PropsWithChildren<EmailConfirmModalProps>
 > = ({ email, expiredTimestamp, onSuccess, onDismiss, refetch: refetch }) => {
   const { values, errors, isSubmitting, onSubmit, register } = useForm();
-  const [timeOver, setTimeOver] = useState(false);
+  const [isTimeOver, setIsTimeOver] = useState(false);
   const { currentTimestamp } = useTimer(0);
   const remainTime = getTimestampDiff(expiredTimestamp, currentTimestamp);
 
@@ -35,11 +35,12 @@ const EmailConfirmModal: React.FC<
 
   const handleReSendClick = () => {
     alert('인증 번호를 재요청했습니다.');
+    setIsTimeOver(false);
     refetch({ email });
   };
 
   const handleSubmit = () => {
-    if (!errors['code'] && !timeOver) {
+    if (!errors['code'] && !isTimeOver) {
       codeVerifyMutation.mutate({
         email,
         verifyCode: values['code'] as string,
@@ -49,7 +50,7 @@ const EmailConfirmModal: React.FC<
 
   useEffect(() => {
     if (expiredTimestamp - currentTimestamp <= 0) {
-      setTimeOver(true);
+      setIsTimeOver(true);
     }
   }, [expiredTimestamp, currentTimestamp]);
 
@@ -62,9 +63,9 @@ const EmailConfirmModal: React.FC<
       <S.Form {...onSubmit(handleSubmit)}>
         <S.InputBox>
           <S.NumberInput
+            type="number"
+            placeholder={isTimeOver ? '인증시간 만료' : '123456'}
             {...register('code', {
-              type: 'number',
-              placeholder: '123456',
               required: true,
               watch: true,
               customValidations: [
@@ -74,13 +75,16 @@ const EmailConfirmModal: React.FC<
                 },
               ],
             })}
+            disabled={isTimeOver}
           />
           <S.ExpiredTimeParagraph>{remainTime}</S.ExpiredTimeParagraph>
         </S.InputBox>
-        {errors['code'] || !values['code'] ? (
-          <S.Button onClick={handleReSendClick}>인증번호 재요청</S.Button>
+        {errors['code'] || !values['code'] || isTimeOver ? (
+          <S.ResendButton onClick={handleReSendClick}>
+            인증번호 재요청
+          </S.ResendButton>
         ) : (
-          <S.Button disabled={isSubmitting || timeOver}>확인</S.Button>
+          <S.ConfirmButton disabled={isSubmitting}>확인</S.ConfirmButton>
         )}
       </S.Form>
       <S.CloseButton onClick={onDismiss}>Ⅹ</S.CloseButton>

--- a/frontend/src/components/EmailConfirmModal/index.tsx
+++ b/frontend/src/components/EmailConfirmModal/index.tsx
@@ -87,7 +87,7 @@ const EmailConfirmModal: React.FC<
     <S.Layout>
       <S.Paragraph>
         <span>이메일로 전송된</span>
-        <span>인증번호 6자리를 입력해주세요</span>
+        <span>인증번호 6자리를 입력해주세요.</span>
       </S.Paragraph>
       <S.Form onSubmit={handleSubmit}>
         <S.InputBox>

--- a/frontend/src/mocks/handlers/userHandler.ts
+++ b/frontend/src/mocks/handlers/userHandler.ts
@@ -47,7 +47,7 @@ export default [
 
       if (users.some((user) => user.email === email)) {
         return res(
-          ctx.status(400),
+          ctx.status(409),
           ctx.json({
             message: '중복된 이메일입니다.',
           }),

--- a/frontend/src/mocks/handlers/userHandler.ts
+++ b/frontend/src/mocks/handlers/userHandler.ts
@@ -332,7 +332,7 @@ export default [
       }
 
       const timer = new Date();
-      timer.setMinutes(timer.getMinutes() + 1);
+      timer.setMinutes(timer.getMinutes() + 5);
       emailExpiredTime = timer.getTime();
 
       return res(

--- a/frontend/src/mocks/handlers/userHandler.ts
+++ b/frontend/src/mocks/handlers/userHandler.ts
@@ -332,7 +332,7 @@ export default [
       }
 
       const timer = new Date();
-      timer.setMinutes(timer.getMinutes() + 5);
+      timer.setMinutes(timer.getMinutes() + 1);
       emailExpiredTime = timer.getTime();
 
       return res(

--- a/frontend/src/mocks/handlers/userHandler.ts
+++ b/frontend/src/mocks/handlers/userHandler.ts
@@ -47,7 +47,7 @@ export default [
 
       if (users.some((user) => user.email === email)) {
         return res(
-          ctx.status(409),
+          ctx.status(400),
           ctx.json({
             message: '중복된 이메일입니다.',
           }),
@@ -323,7 +323,7 @@ export default [
 
       if (isExist) {
         return res(
-          ctx.status(400),
+          ctx.status(409),
           ctx.json({
             message: '중복된 이메일입니다.',
           }),

--- a/frontend/src/mocks/handlers/userHandler.ts
+++ b/frontend/src/mocks/handlers/userHandler.ts
@@ -303,7 +303,7 @@ export default [
   ),
 
   rest.post<UserEmailSendRequestBody>(
-    `${process.env.API_SERVER_HOST}/emails/send`,
+    `${process.env.API_SERVER_HOST}/email/send`,
     (req, res, ctx) => {
       const { email } = req.body;
 
@@ -346,7 +346,7 @@ export default [
   ),
 
   rest.post<EmailCodeVerifyRequestBody>(
-    `${process.env.API_SERVER_HOST}/emails/verify`,
+    `${process.env.API_SERVER_HOST}/email/verify`,
     (req, res, ctx) => {
       const { email, verifyCode } = req.body;
       const authCode = '123456';

--- a/frontend/src/pages/RegisterPage/index.tsx
+++ b/frontend/src/pages/RegisterPage/index.tsx
@@ -51,7 +51,9 @@ const RegisterPage = () => {
   const handleEmailCheckButtonClick: React.MouseEventHandler<
     HTMLButtonElement
   > = () => {
-    emailSendMutation.mutate({ email: values['email'] as string });
+    if (typeof values['email'] === 'string') {
+      emailSendMutation.mutate({ email: values['email'] });
+    }
   };
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {

--- a/frontend/src/pages/RegisterPage/index.tsx
+++ b/frontend/src/pages/RegisterPage/index.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import * as S from './RegisterPage.styled';
 import Input from 'components/@shared/Input';
 import InputHint from 'components/@shared/InputHint';
@@ -13,7 +12,6 @@ import ModalPortal from 'components/ModalPortal';
 import EmailConfirmModal from 'components/EmailConfirmModal';
 
 const RegisterPage = () => {
-  const navigate = useNavigate();
   const { login } = useContext(userContext) as UserContextValues;
   const { values, errors, isSubmitting, onSubmit, register } = useForm();
   const [isModalOpened, setIsModalOpened] = useState(false);
@@ -25,8 +23,22 @@ const RegisterPage = () => {
       setExpiredTimestamp(expiredTime);
       setIsModalOpened(true);
     },
-    onError: () => {
-      alert('이메일 인증하기를 실패했습니다.');
+    onError: ({ message }) => {
+      const status = message.split(': ')[0];
+
+      switch (status) {
+        case '409': {
+          alert('이미 존재하는 이메일 입니다.');
+          break;
+        }
+        case '500': {
+          alert('이메일 발송에 실패했습니다.');
+          break;
+        }
+        default: {
+          alert('이메일 인증하기를 실패했습니다.');
+        }
+      }
     },
   });
 

--- a/frontend/src/pages/RegisterPage/index.tsx
+++ b/frontend/src/pages/RegisterPage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useRef, useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as S from './RegisterPage.styled';
 import Input from 'components/@shared/Input';

--- a/frontend/src/pages/RegisterPage/index.tsx
+++ b/frontend/src/pages/RegisterPage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as S from './RegisterPage.styled';
 import Input from 'components/@shared/Input';
@@ -6,37 +6,31 @@ import InputHint from 'components/@shared/InputHint';
 import Button from 'components/@shared/Button';
 import { userContext, UserContextValues } from 'contexts/userContext';
 import useForm from 'hooks/useForm';
-import useQuery from 'hooks/useQuery';
 import useMutation from 'hooks/useMutation';
 import { UserRegisterRequestBody } from 'types/userType';
-import { checkEmailApi, submitRegisterApi } from 'apis/userApis';
+import { postEmailSendApi, submitRegisterApi } from 'apis/userApis';
+import ModalPortal from 'components/ModalPortal';
+import EmailConfirmModal from 'components/EmailConfirmModal';
 
 const RegisterPage = () => {
   const navigate = useNavigate();
   const { login } = useContext(userContext) as UserContextValues;
   const { values, errors, isSubmitting, onSubmit, register } = useForm();
-  const [isEmailExist, setIsEmailExist] = useState(true);
+  const [isModalOpened, setIsModalOpened] = useState(false);
+  const [expiredTimestamp, setExpiredTimestamp] = useState(0);
+  const [isEmailVerified, setIsEmailVerified] = useState(false);
 
-  const { refetch: checkEmailRefetch } = useQuery(
-    ['checkEmail'],
-    checkEmailApi(values['email'] as string),
-    {
-      enabled: false,
-      onSuccess: ({ body: { isExist } }) => {
-        setIsEmailExist(isExist);
-        const message = isExist
-          ? '중복된 이메일입니다.'
-          : '사용 가능한 이메일입니다.';
+  const emailSendMutation = useMutation(postEmailSendApi, {
+    onSuccess: ({ body: { expiredTime } }) => {
+      setExpiredTimestamp(expiredTime);
+      setIsModalOpened(true);
+    },
+    onError: () => {
+      alert('이메일 인증하기를 실패했습니다.');
+    },
+  });
 
-        alert(message);
-      },
-      onError: () => {
-        alert('이메일 중복확인을 실패했습니다.');
-      },
-    }
-  );
-
-  const { mutate: registerMutate } = useMutation(submitRegisterApi, {
+  const registerMutation = useMutation(submitRegisterApi, {
     onSuccess: ({ body: userData, accessToken }) => {
       login(userData, accessToken);
       navigate('/');
@@ -46,14 +40,18 @@ const RegisterPage = () => {
     },
   });
 
-  const handleCheckEmailButtonClick: React.MouseEventHandler<
+  const handleClose = () => {
+    setIsModalOpened(false);
+  };
+
+  const handleEmailCheckButtonClick: React.MouseEventHandler<
     HTMLButtonElement
   > = () => {
-    checkEmailRefetch();
+    emailSendMutation.mutate({ email: values['email'] as string });
   };
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {
-    if (isEmailExist) {
+    if (isEmailVerified) {
       throw e;
     }
 
@@ -64,129 +62,145 @@ const RegisterPage = () => {
       formData.entries()
     ) as UserRegisterRequestBody;
 
-    await registerMutate(formDataObject);
+    await registerMutation.mutate(formDataObject);
   };
 
   return (
-    <S.Layout>
-      <S.Form id="register-form" {...onSubmit(handleSubmit)}>
-        <S.FieldBox>
-          <S.Label>
-            이메일
-            <S.EmailBox>
-              <S.EmailInput
-                type="email"
-                {...register('email', {
+    <>
+      {isModalOpened && (
+        <ModalPortal closePortal={handleClose}>
+          <EmailConfirmModal
+            email={values['email'] as string}
+            expiredTimestamp={expiredTimestamp}
+            setIsEmailVerified={setIsEmailVerified}
+            onDismiss={handleClose}
+            refetchHandler={emailSendMutation.mutate}
+          />
+        </ModalPortal>
+      )}
+      <S.Layout>
+        <S.Form id="register-form" {...onSubmit(handleSubmit)}>
+          <S.FieldBox>
+            <S.Label>
+              이메일
+              <S.EmailBox>
+                <S.EmailInput
+                  type="email"
+                  {...register('email', {
+                    required: true,
+                    maxLength: 50,
+                    watch: true,
+                    onChange: () => {
+                      setIsEmailVerified(false);
+                    },
+                    disabled: isEmailVerified,
+                  })}
+                  placeholder="이메일을 입력해주세요."
+                />
+                <S.EmailCheckButton
+                  type="button"
+                  variant="confirm"
+                  onClick={handleEmailCheckButtonClick}
+                  disabled={
+                    !values['email'] ||
+                    errors['email'] !== '' ||
+                    isEmailVerified
+                  }
+                >
+                  {isEmailVerified ? '인증완료' : '인증하기'}
+                </S.EmailCheckButton>
+              </S.EmailBox>
+            </S.Label>
+            <InputHint
+              isShow={Boolean(errors['email']) && errors['email'] !== ''}
+              message={errors['email']}
+            />
+          </S.FieldBox>
+          <S.FieldBox>
+            <S.Label>
+              비밀번호
+              <Input
+                type="password"
+                {...register('password', {
+                  pattern:
+                    '(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,30}',
+                  patternValidationMessage:
+                    '8에서 30자리 이하의 영어, 숫자, 특수문자로 입력해주세요.',
+                  onChange: (e, inputController) => {
+                    inputController['passwordConfirm'].checkValidity();
+                  },
+                  minLength: 8,
+                  maxLength: 30,
                   required: true,
-                  onChange: () => {
-                    setIsEmailExist(true);
-                  },
-                  maxLength: 50,
-                  watch: true,
                 })}
-                placeholder="이메일을 입력해주세요."
+                placeholder="8에서 30자리 이하의 영어, 숫자, 특수문자로 입력해주세요."
               />
-              <S.EmailCheckButton
-                type="button"
-                variant="confirm"
-                onClick={handleCheckEmailButtonClick}
-                disabled={
-                  !values['email'] || errors['email'] !== '' || !isEmailExist
-                }
-              >
-                중복확인
-              </S.EmailCheckButton>
-            </S.EmailBox>
-          </S.Label>
-          <InputHint
-            isShow={Boolean(errors['email']) && errors['email'] !== ''}
-            message={errors['email']}
-          />
-        </S.FieldBox>
-        <S.FieldBox>
-          <S.Label>
-            비밀번호
-            <Input
-              type="password"
-              {...register('password', {
-                pattern:
-                  '(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,30}',
-                patternValidationMessage:
-                  '8에서 30자리 이하의 영어, 숫자, 특수문자로 입력해주세요.',
-                onChange: (e, inputController) => {
-                  inputController['passwordConfirm'].checkValidity();
-                },
-                minLength: 8,
-                maxLength: 30,
-                required: true,
-              })}
-              placeholder="8에서 30자리 이하의 영어, 숫자, 특수문자로 입력해주세요."
+            </S.Label>
+            <InputHint
+              isShow={Boolean(errors['password']) && errors['password'] !== ''}
+              message={errors['password']}
             />
-          </S.Label>
-          <InputHint
-            isShow={Boolean(errors['password']) && errors['password'] !== ''}
-            message={errors['password']}
-          />
-        </S.FieldBox>
-        <S.FieldBox>
-          <S.Label>
-            비밀번호 확인
-            <Input
-              type="password"
-              {...register('passwordConfirm', {
-                customValidations: [
-                  {
-                    validate: (value, inputController) =>
-                      inputController['password'] &&
-                      inputController['passwordConfirm'] &&
-                      inputController['password'].element.value ===
-                        inputController['passwordConfirm'].element.value,
-                    validationMessage: '비밀번호가 다릅니다.',
-                  },
-                ],
-                required: true,
-              })}
+          </S.FieldBox>
+          <S.FieldBox>
+            <S.Label>
+              비밀번호 확인
+              <Input
+                type="password"
+                {...register('passwordConfirm', {
+                  customValidations: [
+                    {
+                      validate: (value, inputController) =>
+                        inputController['password'] &&
+                        inputController['passwordConfirm'] &&
+                        inputController['password'].element.value ===
+                          inputController['passwordConfirm'].element.value,
+                      validationMessage: '비밀번호가 다릅니다.',
+                    },
+                  ],
+                  required: true,
+                })}
+              />
+            </S.Label>
+            <InputHint
+              isShow={
+                Boolean(errors['passwordConfirm']) &&
+                errors['passwordConfirm'] !== ''
+              }
+              message={errors['passwordConfirm']}
             />
-          </S.Label>
-          <InputHint
-            isShow={
-              Boolean(errors['passwordConfirm']) &&
-              errors['passwordConfirm'] !== ''
-            }
-            message={errors['passwordConfirm']}
-          />
-        </S.FieldBox>
-        <S.FieldBox>
-          <S.Label>
-            닉네임
-            <Input
-              type="text"
-              {...register('nickname', {
-                maxLength: 15,
-                pattern: '([a-zA-Z0-9가-힣]){1,15}',
-                patternValidationMessage:
-                  '15자 이하의 영어, 한글, 숫자 조합으로 입력해주세요.',
-                required: true,
-              })}
-              placeholder="15자 이하의 영어, 한글, 숫자 조합으로 입력해주세요."
+          </S.FieldBox>
+          <S.FieldBox>
+            <S.Label>
+              닉네임
+              <Input
+                type="text"
+                {...register('nickname', {
+                  maxLength: 15,
+                  pattern: '([a-zA-Z0-9가-힣]){1,15}',
+                  patternValidationMessage:
+                    '15자 이하의 영어, 한글, 숫자 조합으로 입력해주세요.',
+                  required: true,
+                })}
+                placeholder="15자 이하의 영어, 한글, 숫자 조합으로 입력해주세요."
+              />
+            </S.Label>
+            <InputHint
+              isShow={Boolean(errors['nickname']) && errors['nickname'] !== ''}
+              message={errors['nickname']}
             />
-          </S.Label>
-          <InputHint
-            isShow={Boolean(errors['nickname']) && errors['nickname'] !== ''}
-            message={errors['nickname']}
-          />
-        </S.FieldBox>
-      </S.Form>
-      <S.ButtonBox>
-        <Button type="submit" form="register-form" disabled={isSubmitting}>
-          회원가입
-        </Button>
-        <S.LoginHintParagraph>
-          이미 가입된 계정이 있으신가요?
-          <S.LoginLink to="/login">로그인</S.LoginLink>
-        </S.LoginHintParagraph>
-      </S.ButtonBox>
-    </S.Layout>
+          </S.FieldBox>
+        </S.Form>
+        <S.ButtonBox>
+          <Button type="submit" form="register-form" disabled={isSubmitting}>
+            회원가입
+          </Button>
+          <S.LoginHintParagraph>
+            이미 가입된 계정이 있으신가요?
+            <S.LoginLink to="/login">로그인</S.LoginLink>
+          </S.LoginHintParagraph>
+        </S.ButtonBox>
+      </S.Layout>
+    </>
   );
 };
 

--- a/frontend/src/pages/RegisterPage/index.tsx
+++ b/frontend/src/pages/RegisterPage/index.tsx
@@ -40,7 +40,12 @@ const RegisterPage = () => {
     },
   });
 
-  const handleClose = () => {
+  const handleModalClose = () => {
+    setIsModalOpened(false);
+  };
+
+  const handleEmailConfirmSuccess = () => {
+    setIsEmailVerified(true);
     setIsModalOpened(false);
   };
 
@@ -68,13 +73,13 @@ const RegisterPage = () => {
   return (
     <>
       {isModalOpened && (
-        <ModalPortal closePortal={handleClose}>
+        <ModalPortal closePortal={handleModalClose}>
           <EmailConfirmModal
             email={values['email'] as string}
             expiredTimestamp={expiredTimestamp}
-            setIsEmailVerified={setIsEmailVerified}
-            onDismiss={handleClose}
-            refetchHandler={emailSendMutation.mutate}
+            onSuccess={handleEmailConfirmSuccess}
+            onDismiss={handleModalClose}
+            refetch={emailSendMutation.mutate}
           />
         </ModalPortal>
       )}

--- a/frontend/src/pages/RegisterPage/index.tsx
+++ b/frontend/src/pages/RegisterPage/index.tsx
@@ -33,7 +33,6 @@ const RegisterPage = () => {
   const registerMutation = useMutation(submitRegisterApi, {
     onSuccess: ({ body: userData, accessToken }) => {
       login(userData, accessToken);
-      navigate('/');
     },
     onError: () => {
       alert('회원가입을 실패했습니다.');

--- a/frontend/src/pages/RegisterPage/index.tsx
+++ b/frontend/src/pages/RegisterPage/index.tsx
@@ -56,7 +56,7 @@ const RegisterPage = () => {
   };
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {
-    if (isEmailVerified) {
+    if (!isEmailVerified) {
       throw e;
     }
 
@@ -98,7 +98,7 @@ const RegisterPage = () => {
                     onChange: () => {
                       setIsEmailVerified(false);
                     },
-                    disabled: isEmailVerified,
+                    readOnly: isEmailVerified,
                   })}
                   placeholder="이메일을 입력해주세요."
                 />

--- a/frontend/src/types/userType.ts
+++ b/frontend/src/types/userType.ts
@@ -54,3 +54,10 @@ export type UserCoffeeStatsResponseBody = {
     coffeeCount: number;
   })[];
 };
+
+export type UserEmailSendRequestBody = Pick<User, 'email'>;
+
+export type EmailCodeVerifyRequestBody = {
+  email: User['email'];
+  verifyCode: string;
+};

--- a/frontend/src/utils/timeUtil.ts
+++ b/frontend/src/utils/timeUtil.ts
@@ -75,3 +75,17 @@ export const getAllSameDays = (day: number, begin: Date, end: Date) => {
 
   return dates;
 };
+
+export const getTimestampDiff = (
+  aheadTimestamp: number,
+  behindTimestamp: number
+) => {
+  if (aheadTimestamp <= behindTimestamp) {
+    return '00:00';
+  }
+
+  const minute = Math.floor((aheadTimestamp - behindTimestamp) / 1000 / 60);
+  const second = Math.floor(((aheadTimestamp - behindTimestamp) / 1000) % 60);
+
+  return `${('0' + minute).slice(-2)}:${('0' + second).slice(-2)}`;
+};

--- a/frontend/src/utils/timeUtil.ts
+++ b/frontend/src/utils/timeUtil.ts
@@ -86,6 +86,8 @@ export const getTimestampDiff = (
 
   const minute = Math.floor((aheadTimestamp - behindTimestamp) / 1000 / 60);
   const second = Math.floor(((aheadTimestamp - behindTimestamp) / 1000) % 60);
+  const leftPaddedMinute = minute.toString().padStart(2, '0');
+  const leftPaddedSecond = second.toString().padStart(2, '0');
 
-  return `${('0' + minute).slice(-2)}:${('0' + second).slice(-2)}`;
+  return `${leftPaddedMinute}:${leftPaddedSecond}`;
 };


### PR DESCRIPTION
Close #521 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/fe/verify-email -> dev

## 요구사항

- [x] 회원가입 시 입력한 이메일로 인증코드를 보낸다
- [x] 정상적인 인증 코드를 입력했을 시 완료한다.

## 변경사항
- 중복확인에서 인증하기 버튼으로 변경
- 이메일 인증코드 입력 모달 추가
  - 인증 만료까지 남은 시간을 보여준다.
  - 인증이 완료되었지 않으면 인증하기 버튼 활성화 및 상태 저장
  - 시간 만료되면 입력 막고 “인증 시간이 만료되었습니다” placeholder로 보여준다.
  - 숫자 이외에 입력을 막고, 최대 입력값을 6자리로 제한한다. 
  - 재전송했을 때 시간 달라짐
  - 스토리북 추가
  - 회원가입, 모임 생성 E2E 테스트 코드 수정
  - 이메일 전성, 인증 코드 확인 mocking 추가

