### PR TITLE
[BE] Oauth 로그인 시 이미 가입된 이메일인 경우 해당 유저 데이터로 로그인

### DIFF
--- a/backend/src/main/java/com/woowacourse/moragora/application/UserService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/UserService.java
@@ -57,8 +57,8 @@ public class UserService {
         return savedUser.getId();
     }
 
-    private void confirmEmailVerification(final String email, final String verifitedEmail) {
-        if (!email.equals(verifitedEmail)) {
+    private void confirmEmailVerification(final String email, final String verifiedEmail) {
+        if (!email.equals(verifiedEmail)) {
             throw new AuthCodeException("인증되지 않은 이메일입니다.");
         }
     }

--- a/backend/src/main/java/com/woowacourse/moragora/application/UserService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/UserService.java
@@ -1,6 +1,5 @@
 package com.woowacourse.moragora.application;
 
-import static com.woowacourse.moragora.domain.user.Provider.CHECKMATE;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 
@@ -21,11 +20,11 @@ import com.woowacourse.moragora.exception.ClientRuntimeException;
 import com.woowacourse.moragora.exception.auth.AuthCodeException;
 import com.woowacourse.moragora.exception.global.NoParameterException;
 import com.woowacourse.moragora.exception.user.AuthenticationFailureException;
+import com.woowacourse.moragora.exception.user.EmailDuplicatedException;
 import com.woowacourse.moragora.exception.user.InvalidPasswordException;
 import com.woowacourse.moragora.exception.user.UserNotFoundException;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,7 +49,7 @@ public class UserService {
     public Long create(final UserRequest userRequest, final String verifiedEmail) {
         final String email = userRequest.getEmail();
 
-        validateUserExistsByEmailAndProvider(email);
+        validateUserExistsByEmail(email);
         confirmEmailVerification(email, verifiedEmail);
 
         final User user = userRequest.toEntity();
@@ -115,10 +114,10 @@ public class UserService {
         userRepository.delete(user);
     }
 
-    private void validateUserExistsByEmailAndProvider(final String email) {
-        final Optional<User> user = userRepository.findByEmailAndProvider(email, CHECKMATE);
-        if (user.isPresent()) {
-            throw new ClientRuntimeException("이미 사용중인 이메일입니다.", BAD_REQUEST);
+    private void validateUserExistsByEmail(final String email) {
+        final boolean isExist = userRepository.existsByEmail(email);
+        if (isExist) {
+            throw new EmailDuplicatedException();
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/moragora/application/auth/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/auth/AuthService.java
@@ -73,7 +73,7 @@ public class AuthService {
     public TokenResponse loginWithGoogle(final String code) {
         final String googleIdToken = googleClient.getIdToken(code);
         final GoogleProfileResponse profileResponse = googleClient.getProfileResponse(googleIdToken);
-        final User user = userRepository.findByEmailAndProvider(profileResponse.getEmail(), GOOGLE)
+        final User user = userRepository.findByEmail(profileResponse.getEmail())
                 .orElseGet(() -> saveGoogleUser(profileResponse));
 
         return createTokenResponse(user.getId());

--- a/backend/src/main/java/com/woowacourse/moragora/domain/user/UserRepository.java
+++ b/backend/src/main/java/com/woowacourse/moragora/domain/user/UserRepository.java
@@ -12,6 +12,8 @@ public interface UserRepository extends Repository<User, Long> {
 
     Optional<User> findById(final Long id);
 
+    Optional<User> findByEmail(final String email);
+
     List<User> findByIdIn(final List<Long> ids);
 
     boolean existsByEmail(final String email);

--- a/backend/src/test/java/com/woowacourse/moragora/application/UserServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/application/UserServiceTest.java
@@ -20,6 +20,7 @@ import com.woowacourse.moragora.dto.response.user.UsersResponse;
 import com.woowacourse.moragora.exception.ClientRuntimeException;
 import com.woowacourse.moragora.exception.global.InvalidFormatException;
 import com.woowacourse.moragora.exception.global.NoParameterException;
+import com.woowacourse.moragora.exception.user.EmailDuplicatedException;
 import com.woowacourse.moragora.exception.user.InvalidPasswordException;
 import com.woowacourse.moragora.exception.user.UserNotFoundException;
 import com.woowacourse.moragora.support.DataSupport;
@@ -73,8 +74,7 @@ class UserServiceTest {
 
         // when, then
         assertThatThrownBy(() -> userService.create(userRequest, SUN.getEmail()))
-                .isInstanceOf(ClientRuntimeException.class)
-                .hasMessage("이미 사용중인 이메일입니다.");
+                .isInstanceOf(EmailDuplicatedException.class);
     }
 
     @DisplayName("인증되지 않은 이메일로 회원가입을 하면 예외가 발생한다.")

--- a/backend/src/test/java/com/woowacourse/moragora/application/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/application/auth/AuthServiceTest.java
@@ -181,6 +181,26 @@ class AuthServiceTest {
                 .isEqualTo(expectedResponse);
     }
 
+    @DisplayName("자체 회원가입된 이메일로 구글 로그인을 할 경우 기존의 User id를 반환한다.")
+    @Test
+    void loginWithGoogle_whenExistSameEmail() {
+        // given
+        final User user = dataSupport.saveUser(KUN.create());
+        given(googleClient.getIdToken(anyString()))
+                .willReturn("something");
+        given(googleClient.getProfileResponse(anyString()))
+                .willReturn(new GoogleProfileResponse(user.getEmail(), user.getNickname()));
+        final String expected = String.valueOf(user.getId());
+
+        // when
+        final TokenResponse tokenResponse = authService.loginWithGoogle("code");
+        final String accessToken = tokenResponse.getAccessToken();
+        final String payload = jwtTokenProvider.getPayload(accessToken);
+
+        // then
+        assertThat(payload).isEqualTo(expected);
+    }
+
     @DisplayName("Refresh token이 유효할 경우 새로운 access token과 refresh token을 발급한다.")
     @ParameterizedTest
     @ValueSource(longs = {0, 4, 7})


### PR DESCRIPTION
Close #524 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/email-integration -> dev

## 요구사항
- google oauth 로그인 시 이미 가입된 이메일은 기존의 유저 데이터로 로그인한다.

## 변경사항
- AuthService의 loginWithGoogle 메서드에서 이메일을 조회할 때 provider와 함께 조회하지 않고 이메일만 조회를 한다.

