### PR TITLE
[BE] 시간에 따라 실패하는 테스트 수정

### DIFF
--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/AttendanceAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/AttendanceAcceptanceTest.java
@@ -209,10 +209,14 @@ class AttendanceAcceptanceTest extends AcceptanceTest {
         final List<Long> userIds = saveUsers(createUsers());
         final Meeting meeting = MORAGORA.create();
         final int meetingId = saveMeeting(token, userIds, meeting);
+
         final LocalDate date = LocalDate.now();
-        final Event event = EVENT_WITHOUT_DATE.createEventOnDate(meeting, date);
+        final LocalTime time = LocalTime.of(10, 0);
+        final LocalDateTime now = LocalDateTime.of(date, time.plusMinutes(1));
+        final Event event = EVENT_WITHOUT_DATE.createEventOnDateAndTime(meeting, date, time);
 
         given(serverTimeManager.getDate()).willReturn(date);
+        given(serverTimeManager.getDateAndTime()).willReturn(now);
 
         saveEvents(token, List.of(event), (long) meetingId);
 
@@ -263,13 +267,16 @@ class AttendanceAcceptanceTest extends AcceptanceTest {
         final Long masterId = signUp(master);
         final String token = login(master);
         final LocalDate date = LocalDate.now();
+        final LocalTime time = LocalTime.of(10, 0);
+        final LocalDateTime now = LocalDateTime.of(date, time.plusMinutes(1));
 
         final List<Long> userIds = saveUsers(createUsers());
         final Meeting meeting = MORAGORA.create();
         final int meetingId = saveMeeting(token, userIds, meeting);
-        final Event event = EVENT_WITHOUT_DATE.createEventOnDate(meeting, date);
+        final Event event = EVENT_WITHOUT_DATE.createEventOnDateAndTime(meeting, date, time);
 
         given(serverTimeManager.getDate()).willReturn(date);
+        given(serverTimeManager.getDateAndTime()).willReturn(now);
         saveEvents(token, List.of(event), (long) meetingId);
 
         // when

--- a/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/acceptance/MeetingAcceptanceTest.java
@@ -23,6 +23,7 @@ import com.woowacourse.moragora.dto.request.meeting.MeetingRequest;
 import com.woowacourse.moragora.dto.request.meeting.MeetingUpdateRequest;
 import io.restassured.response.ValidatableResponse;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -107,11 +108,15 @@ class MeetingAcceptanceTest extends AcceptanceTest {
         final int meetingId2 = saveMeeting(token, ids, meeting2);
 
         final LocalDate today = LocalDate.now();
-        final Event event = EVENT_WITHOUT_DATE.createEventOnDate(meeting1, today);
+        final LocalTime time = LocalTime.of(10, 0);
+        final LocalDateTime now = LocalDateTime.of(today, time.plusMinutes(1));
+
+        final Event event = EVENT_WITHOUT_DATE.createEventOnDateAndTime(meeting1, today, time);
 
         given(serverTimeManager.getDate())
                 .willReturn(event.getDate());
-        given(serverTimeManager.isAttendanceOpen(LocalTime.of(10, 0)))
+        given(serverTimeManager.getDateAndTime()).willReturn(now);
+        given(serverTimeManager.isAttendanceOpen(time))
                 .willReturn(true);
         given(serverTimeManager.calculateOpenTime(event.getStartTime()))
                 .willReturn(LocalTime.of(9, 30));


### PR DESCRIPTION
Close #538 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/test-fix -> dev

## 요구사항
- 시간에 따라 실패하는 테스트를 성공시킨다.

## 변경사항
- 이슈에 기대동작과 현재 동작에 대해 자세하게 써놓았습니다. 한번 확인해주세요~
https://github.com/woowacourse-teams/2022-moragora/issues/538

- EventFixtures의 시간을 파라미터로 전달받는 createEventOnDateAndTime으로 Event를 생성하고 파라미터로 넘겨준 시간보다 더 큰 시간으로 serverTimeManager.getDateAndTime을 mocking 하였습니다.

