### PR TITLE
[BE] Token 재발행시 유저 검증 로직 제거

### DIFF
--- a/backend/src/main/java/com/woowacourse/moragora/application/UserService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/UserService.java
@@ -57,12 +57,6 @@ public class UserService {
         return savedUser.getId();
     }
 
-    private void confirmEmailVerification(final String email, final String verifiedEmail) {
-        if (!email.equals(verifiedEmail)) {
-            throw new AuthCodeException("인증되지 않은 이메일입니다.");
-        }
-    }
-
     public UsersResponse searchByKeyword(final String keyword) {
         validateKeyword(keyword);
         final List<User> searchedUsers = userRepository.findByNicknameOrEmailLike(keyword);
@@ -112,6 +106,12 @@ public class UserService {
         attendanceRepository.deleteByParticipantIdIn(participantIds);
         participantRepository.deleteByIdIn(participantIds);
         userRepository.delete(user);
+    }
+
+    private void confirmEmailVerification(final String email, final String verifiedEmail) {
+        if (!email.equals(verifiedEmail)) {
+            throw new AuthCodeException("인증되지 않은 이메일입니다.");
+        }
     }
 
     private void validateUserExistsByEmail(final String email) {

--- a/backend/src/main/java/com/woowacourse/moragora/application/auth/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/moragora/application/auth/AuthService.java
@@ -92,7 +92,6 @@ public class AuthService {
                 .orElseThrow(InvalidTokenException::new);
         removeRefreshToken(oldToken);
         validateRefreshTokenExpiration(refreshToken);
-        validateUserExists(refreshToken);
 
         return createTokenResponse(refreshToken.getUserId());
     }
@@ -129,12 +128,6 @@ public class AuthService {
 
     private void validateRefreshTokenExpiration(final RefreshToken refreshToken) {
         if (refreshToken.isExpiredAt(serverTimeManager.getDateAndTime())) {
-            throw new InvalidTokenException();
-        }
-    }
-
-    private void validateUserExists(final RefreshToken refreshToken) {
-        if (!userRepository.existsById(refreshToken.getUserId())) {
             throw new InvalidTokenException();
         }
     }

--- a/backend/src/test/java/com/woowacourse/moragora/application/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moragora/application/auth/AuthServiceTest.java
@@ -256,25 +256,6 @@ class AuthServiceTest {
                 .isInstanceOf(InvalidTokenException.class);
     }
 
-    @DisplayName("Refresh token에 해당하는 유저가 존재하지 않는 경우 예외가 발생한다.")
-    @Test
-    void refreshTokens_ifUserNotExists_throwsException() {
-        // given
-        final String email = "kun@email.com";
-        final String password = "qwerasdf123!";
-        final UserRequest userRequest = new UserRequest(email, password, "kun");
-        final Long userId = userService.create(userRequest, email);
-
-        final LoginRequest loginRequest = new LoginRequest(email, password);
-        final TokenResponse tokenResponse = authService.login(loginRequest);
-
-        // when, then
-        userService.delete(new UserDeleteRequest(password), userId);
-        serverTimeManager.refresh(LocalDateTime.now());
-        assertThatThrownBy(() -> authService.refreshTokens(tokenResponse.getRefreshToken()))
-                .isInstanceOf(InvalidTokenException.class);
-    }
-
     @DisplayName("인증 코드를 메일로 전송하고 세션에 이메일 인증관련 정보들을 저장한다.")
     @Test
     void sendAuthCode() {


### PR DESCRIPTION
<!--Close #issue_number를 작성한다.-->
Close #559 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/be/refresh -> dev

## 요구사항
- Token 재발행시 DB로부터 유저가 존재하는지 검증하는 로직을 제거한다.

## 변경사항

## [Optional] 논의하고 싶은 내용

